### PR TITLE
Add missing merge clauses in DeltaTableWriter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Fetch main branch
       run: git fetch origin main:main
     - name: Check changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.ref }}
     - name: Fetch main branch
       run: git fetch origin main:main
     - name: Check changes

--- a/src/koheesio/spark/writers/delta/batch.py
+++ b/src/koheesio/spark/writers/delta/batch.py
@@ -233,7 +233,7 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
 
         return self.__merge(merge_builder=builder)
 
-    def _get_merge_builder(self, provided_merge_builder=None):
+    def _get_merge_builder(self, provided_merge_builder=None) -> DeltaMergeBuilder:
         """Resolves the merge builder. If provided, it will be used, otherwise it will be created from the args"""
 
         # A merge builder has been already created - case for merge_all

--- a/src/koheesio/spark/writers/delta/batch.py
+++ b/src/koheesio/spark/writers/delta/batch.py
@@ -274,19 +274,8 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
             .merge(self.df.alias(source_alias), merge_cond)
         )
 
-        valid_clauses = [
-            "whenMatchedUpdate",
-            "whenNotMatchedInsert",
-            "whenMatchedDelete",
-            "whenNotMatchedBySourceUpdate",
-            "whenNotMatchedBySourceDelete",
-        ]
-
         for merge_clause in merge_clauses:
             clause_type = merge_clause.pop("clause", None)
-            if clause_type not in valid_clauses:
-                raise ValueError(f"Invalid merge clause '{clause_type}' provided")
-
             method = getattr(builder, clause_type)
             builder = method(**merge_clause)
 
@@ -313,6 +302,25 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
         if isinstance(table, str):
             return DeltaTableStep(table=table)
         return table
+
+    @field_validator("params")
+    def _validate_params(cls, params):
+        """Validates params. If an array of merge clauses is provided, they will be validated against the available
+        ones in DeltaMergeBuilder"""
+
+        valid_clauses = {m for m in dir(DeltaMergeBuilder) if m.startswith("when")}
+
+        if "merge_builder" in params:
+            merge_builder = params["merge_builder"]
+            if isinstance(merge_builder, list):
+                for merge_conf in merge_builder:
+                    clause = merge_conf.get("clause")
+                    if clause not in valid_clauses:
+                        raise ValueError(f"Invalid merge clause '{clause}' provided")
+            elif not isinstance(merge_builder, DeltaMergeBuilder):
+                raise ValueError("merge_builder must be a list or merge clauses or a DeltaMergeBuilder instance")
+
+        return params
 
     @classmethod
     def get_output_mode(cls, choice: str, options: Set[Type]) -> Union[BatchOutputMode, StreamingOutputMode]:


### PR DESCRIPTION
## Description
DeltaTableWriter provides the option to configure the writer in MERGE mode using the output_mode_params field by providing in it a list of merge clauses in the merge_builder key. This is especially useful in case the Delta table or the DataFrame to be merged are not available upfront. Not all merge clauses were supported: the merge clause provided was being validated against a list of valid clauses which did not include **whenMatchedUpdateAll** and **whenNotMatchedInsertAll** clauses. As part of this PR:
- validation of the clauses now happens in the output_mode_params field validator (currently this is happening only when the merge is being executed)
- the list of available merge clauses is sourced directly from available methods in DeltaMergeBuilder class and now includes all of them

## Related Issue
https://github.com/Nike-Inc/koheesio/issues/43


## Motivation and Context
Now it's possible to use all merge clauses when configuring the DeltaTableWriter 

## How Has This Been Tested?
Tests covering validation errors have been added

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
