### PR TITLE
[FIX] - Snowflake reader and writer have different parameter names for table name 

### DIFF
--- a/src/koheesio/integrations/spark/tableau/hyper.py
+++ b/src/koheesio/integrations/spark/tableau/hyper.py
@@ -301,6 +301,7 @@ class HyperFileDataFrameWriter(HyperFileWriter):
     hw.hyper_path
     ```
     """
+
     df: DataFrame = Field(default=..., description="Spark DataFrame to write to the Hyper file")
     table_definition: Optional[TableDefinition] = None  # table_definition is not required for this class
 

--- a/src/koheesio/integrations/spark/tableau/server.py
+++ b/src/koheesio/integrations/spark/tableau/server.py
@@ -23,6 +23,7 @@ class TableauServer(Step):
     """
     Base class for Tableau server interactions. Class provides authentication and project identification functionality.
     """
+
     url: str = Field(
         default=...,
         alias="url",
@@ -190,6 +191,7 @@ class TableauHyperPublisher(TableauServer):
     """
     Publish the given Hyper file to the Tableau server. Hyper file will be treated by Tableau server as a datasource.
     """
+
     datasource_name: str = Field(default=..., description="Name of the datasource to publish")
     hyper_path: PurePath = Field(default=..., description="Path to Hyper file")
     publish_mode: TableauHyperPublishMode = Field(

--- a/src/koheesio/spark/readers/jdbc.py
+++ b/src/koheesio/spark/readers/jdbc.py
@@ -67,7 +67,9 @@ class JdbcReader(Reader):
     )
     user: str = Field(default=..., description="User to authenticate to the server")
     password: SecretStr = Field(default=..., description="Password belonging to the username")
-    dbtable: Optional[str] = Field(default=None, description="Database table name, also include schema name")
+    dbtable: Optional[str] = Field(
+        default=None, description="Database table name, also include schema name", alias="table"
+    )
     query: Optional[str] = Field(default=None, description="Query")
     options: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Extra options to pass to spark reader")
 

--- a/tests/spark/integrations/snowflake/test_snowflake.py
+++ b/tests/spark/integrations/snowflake/test_snowflake.py
@@ -39,29 +39,34 @@ COMMON_OPTIONS = {
     "warehouse": "warehouse",
 }
 
+
 def test_snowflake_module_import():
     # test that the pass-through imports in the koheesio.spark snowflake modules are working
-    from koheesio.spark.writers import snowflake as snowflake_readers
     from koheesio.spark.readers import snowflake as snowflake_writers
+    from koheesio.spark.writers import snowflake as snowflake_readers
 
 
 class TestSnowflakeReader:
-    reader_options = {"dbtable": "table", **COMMON_OPTIONS}
-
-    def test_get_options(self):
-        sf = SnowflakeReader(**(self.reader_options | {"authenticator": None}))
+    @pytest.mark.parametrize(
+        "reader_options", [{"dbtable": "table", **COMMON_OPTIONS}, {"table": "table", **COMMON_OPTIONS}]
+    )
+    def test_get_options(self, reader_options):
+        sf = SnowflakeReader(**(reader_options | {"authenticator": None}))
         o = sf.get_options()
         assert sf.format == "snowflake"
         assert o["sfUser"] == "user"
         assert o["sfCompress"] == "on"
         assert "authenticator" not in o
 
-    def test_execute(self, dummy_spark):
+    @pytest.mark.parametrize(
+        "reader_options", [{"dbtable": "table", **COMMON_OPTIONS}, {"table": "table", **COMMON_OPTIONS}]
+    )
+    def test_execute(self, dummy_spark, reader_options):
         """Method should be callable from parent class"""
         with mock.patch.object(SparkSession, "getActiveSession") as mock_spark:
             mock_spark.return_value = dummy_spark
 
-            k = SnowflakeReader(**self.reader_options).execute()
+            k = SnowflakeReader(**reader_options).execute()
             assert k.df.count() == 1
 
 


### PR DESCRIPTION
## Description
SnowflakeReader and SnowflakeWriter have different parameter names for the table name

## Related Issue
https://github.com/Nike-Inc/koheesio/issues/65

## Motivation and Context
It would improve usability using the same parameter for the table name in both SnowflakeReader and SnowflakeWriter


## How Has This Been Tested?
We have added tests to cover the table parameter being passed as "table" instead of "dbtable"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
