### PR TITLE
[BUGFIX] Tableau Hyper generation on DBFS is broken

### DIFF
--- a/src/koheesio/integrations/spark/tableau/hyper.py
+++ b/src/koheesio/integrations/spark/tableau/hyper.py
@@ -148,7 +148,7 @@ class HyperFileWriter(HyperFile):
         default=TemporaryDirectory().name,
         description="Path to the Hyper file, if executing in Databricks "
         "set the path manually and ensure to specify the scheme `dbfs:/`.",
-        examples=["PurePath(/tmp/hyper/)", "PurePath(dbfs:/tmp/hyper/)"]
+        examples=["PurePath(/tmp/hyper/)", "PurePath(dbfs:/tmp/hyper/)"],
     )
     name: str = Field(default="extract", description="Name of the Hyper file")
     table_definition: TableDefinition = Field(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added the guidance to use `dbfs:/` scheme and configure the path for the Hyper file manually during the class initialization
- Substitute the `dbfs:` sceme with POSIX-style notation `/dbfs`, to make the path compatible with `os.walk`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#72 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes the above mentioned issue, otherwise the `HyperFileDataFrameWriter` class does not work in DBX

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local tests / local code
- build wheel and install manuall on the DBX cluster, executed the code before and after fix

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
