### PR TITLE
fix for DeltaMergeBuilder, when the instance doesn't check out

### DIFF
--- a/src/koheesio/spark/writers/delta/batch.py
+++ b/src/koheesio/spark/writers/delta/batch.py
@@ -232,7 +232,7 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
 
         return self.__merge(merge_builder=builder)
 
-    def _get_merge_builder(self, provided_merge_builder: DeltaMergeBuilder = None) -> DeltaMergeBuilder:
+    def _get_merge_builder(self, provided_merge_builder: DeltaMergeBuilder = None) -> "DeltaMergeBuilder":
         """Resolves the merge builder. If provided, it will be used, otherwise it will be created from the args"""
 
         # A merge builder has been already created - case for merge_all
@@ -250,6 +250,11 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
         if merge_builder:
             if isinstance(merge_builder, DeltaMergeBuilder):
                 return merge_builder
+
+            if type(merge_builder).__name__ == "DeltaMergeBuilder":
+                # This check is to account for the case when the merge_builder is not a DeltaMergeBuilder instance, but
+                # still a compatible object
+                return merge_builder  # type: ignore
 
             if isinstance(merge_builder, list) and "merge_cond" in self.params:  # type: ignore
                 return self._merge_builder_from_args()


### PR DESCRIPTION
…but the name does (i.e. when using Databricks' Delta Connect library)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
...

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#101 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a Databricks cluster running connet

## Screenshots (if appropriate):
...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
