### PR TITLE
[Fix] Add overwrite functionality to the BoxFileWriterClass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
   { name = "Danny Meijer", email = "danny.meijer@nike.com" },
   { name = "Mikita Sakalouski", email = "mikita.sakalouski@nike.com" },
   { name = "Maxim Mityutko", email = "maxim.mityutko@nike.com" },
+  { name = "Tone Vanden Bergh", email = "tone.vandenbergh@nike.com"},
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an `overwrite` flag to the `BoxFileWriter` class

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Parially solves #89 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When writing to box and the file already exists, you want to be able to overwrite the existing file with a new version

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on databricks and box - when a file exists and doesn't, the writer does the right thing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
