### PR TITLE
[FIX] Accidental duplication of logs

### DIFF
--- a/src/koheesio/asyncio/__init__.py
+++ b/src/koheesio/asyncio/__init__.py
@@ -67,9 +67,7 @@ class AsyncStepOutput(Step.Output):
         --------
         ```python
         step_output = StepOutput(foo="bar")
-        step_output.merge(
-            {"lorem": "ipsum"}
-        )  # step_output will now contain {'foo': 'bar', 'lorem': 'ipsum'}
+        step_output.merge({"lorem": "ipsum"})  # step_output will now contain {'foo': 'bar', 'lorem': 'ipsum'}
         ```
 
         Functionally similar to adding two dicts together; like running `{**dict_a, **dict_b}`.

--- a/src/koheesio/integrations/box.py
+++ b/src/koheesio/integrations/box.py
@@ -619,16 +619,12 @@ class BoxFileWriter(BoxFolderBase):
     from koheesio.steps.integrations.box import BoxFileWriter
 
     auth_params = {...}
-    f1 = BoxFileWriter(
-        **auth_params, path="/foo/bar", file="path/to/my/file.ext"
-    ).execute()
+    f1 = BoxFileWriter(**auth_params, path="/foo/bar", file="path/to/my/file.ext").execute()
     # or
     import io
 
     b = io.BytesIO(b"my-sample-data")
-    f2 = BoxFileWriter(
-        **auth_params, path="/foo/bar", file=b, name="file.ext"
-    ).execute()
+    f2 = BoxFileWriter(**auth_params, path="/foo/bar", file=b, name="file.ext").execute()
     ```
     """
 

--- a/src/koheesio/integrations/snowflake/test_utils.py
+++ b/src/koheesio/integrations/snowflake/test_utils.py
@@ -25,9 +25,7 @@ def mock_query() -> Generator:
         mock_query.expected_data = [("row1",), ("row2",)]
 
         # Act
-        instance = SnowflakeRunQueryPython(
-            **COMMON_OPTIONS, query=query, account="42"
-        )
+        instance = SnowflakeRunQueryPython(**COMMON_OPTIONS, query=query, account="42")
         instance.execute()
 
         # Assert

--- a/src/koheesio/integrations/spark/tableau/hyper.py
+++ b/src/koheesio/integrations/spark/tableau/hyper.py
@@ -199,15 +199,9 @@ class HyperFileListWriter(HyperFileWriter):
         table_definition=TableDefinition(
             table_name=TableName("Extract", "Extract"),
             columns=[
-                TableDefinition.Column(
-                    name="string", type=SqlType.text(), nullability=NOT_NULLABLE
-                ),
-                TableDefinition.Column(
-                    name="int", type=SqlType.int(), nullability=NULLABLE
-                ),
-                TableDefinition.Column(
-                    name="timestamp", type=SqlType.timestamp(), nullability=NULLABLE
-                ),
+                TableDefinition.Column(name="string", type=SqlType.text(), nullability=NOT_NULLABLE),
+                TableDefinition.Column(name="int", type=SqlType.int(), nullability=NULLABLE),
+                TableDefinition.Column(name="timestamp", type=SqlType.timestamp(), nullability=NULLABLE),
             ],
         ),
         data=[
@@ -261,15 +255,9 @@ class HyperFileParquetWriter(HyperFileWriter):
         table_definition=TableDefinition(
             table_name=TableName("Extract", "Extract"),
             columns=[
-                TableDefinition.Column(
-                    name="string", type=SqlType.text(), nullability=NOT_NULLABLE
-                ),
-                TableDefinition.Column(
-                    name="int", type=SqlType.int(), nullability=NULLABLE
-                ),
-                TableDefinition.Column(
-                    name="timestamp", type=SqlType.timestamp(), nullability=NULLABLE
-                ),
+                TableDefinition.Column(name="string", type=SqlType.text(), nullability=NOT_NULLABLE),
+                TableDefinition.Column(name="int", type=SqlType.int(), nullability=NULLABLE),
+                TableDefinition.Column(name="timestamp", type=SqlType.timestamp(), nullability=NULLABLE),
             ],
         ),
         files=[

--- a/src/koheesio/models/__init__.py
+++ b/src/koheesio/models/__init__.py
@@ -407,9 +407,7 @@ class BaseModel(PydanticBaseModel, ABC):  # type: ignore[no-redef]
         ```python
         step_output_1 = StepOutput(foo="bar")
         step_output_2 = StepOutput(lorem="ipsum")
-        (
-            step_output_1 + step_output_2
-        )  # step_output_1 will now contain {'foo': 'bar', 'lorem': 'ipsum'}
+        (step_output_1 + step_output_2)  # step_output_1 will now contain {'foo': 'bar', 'lorem': 'ipsum'}
         ```
 
         Parameters
@@ -533,9 +531,7 @@ class BaseModel(PydanticBaseModel, ABC):  # type: ignore[no-redef]
         --------
         ```python
         step_output = StepOutput(foo="bar")
-        step_output.merge(
-            {"lorem": "ipsum"}
-        )  # step_output will now contain {'foo': 'bar', 'lorem': 'ipsum'}
+        step_output.merge({"lorem": "ipsum"})  # step_output will now contain {'foo': 'bar', 'lorem': 'ipsum'}
         ```
 
         Parameters

--- a/src/koheesio/spark/readers/file_loader.py
+++ b/src/koheesio/spark/readers/file_loader.py
@@ -80,9 +80,7 @@ class FileLoader(Reader, ExtraParamsMixin):
 
     Example:
     ```python
-    reader = FileLoader(
-        path="path/to/textfile.txt", format="text", header=True, lineSep="\n"
-    )
+    reader = FileLoader(path="path/to/textfile.txt", format="text", header=True, lineSep="\n")
     ```
 
     For more information about the available options, see Spark's

--- a/src/koheesio/spark/readers/rest_api.py
+++ b/src/koheesio/spark/readers/rest_api.py
@@ -70,9 +70,7 @@ class RestApiReader(Reader):
         pages=3,
         session=session,
     )
-    task = RestApiReader(
-        transport=transport, spark_schema="id: int, page:int, value: string"
-    )
+    task = RestApiReader(transport=transport, spark_schema="id: int, page:int, value: string")
     task.execute()
     all_data = [row.asDict() for row in task.output.df.collect()]
     ```
@@ -97,9 +95,7 @@ class RestApiReader(Reader):
         connector=connector,
     )
 
-    task = RestApiReader(
-        transport=transport, spark_schema="id: int, page:int, value: string"
-    )
+    task = RestApiReader(transport=transport, spark_schema="id: int, page:int, value: string")
     task.execute()
     all_data = [row.asDict() for row in task.output.df.collect()]
     ```

--- a/src/koheesio/spark/transformations/__init__.py
+++ b/src/koheesio/spark/transformations/__init__.py
@@ -56,9 +56,7 @@ class Transformation(SparkStep, ABC):
 
     class AddOne(Transformation):
         def execute(self):
-            self.output.df = self.df.withColumn(
-                "new_column", f.col("old_column") + 1
-            )
+            self.output.df = self.df.withColumn("new_column", f.col("old_column") + 1)
     ```
 
     In the example above, the `execute` method is implemented to add 1 to the values of the `old_column` and store the

--- a/src/koheesio/spark/transformations/camel_to_snake.py
+++ b/src/koheesio/spark/transformations/camel_to_snake.py
@@ -48,9 +48,7 @@ class CamelToSnakeTransformation(ColumnsTransformation):
     | ...                | ...               |
 
     ```python
-    output_df = CamelToSnakeTransformation(column="camelCaseColumn").transform(
-        input_df
-    )
+    output_df = CamelToSnakeTransformation(column="camelCaseColumn").transform(input_df)
     ```
 
     __output_df:__

--- a/src/koheesio/spark/transformations/date_time/interval.py
+++ b/src/koheesio/spark/transformations/date_time/interval.py
@@ -102,14 +102,10 @@ from koheesio.spark.transformations.date_time.interval import (
     DateTimeAddInterval,
 )
 
-input_df = spark.createDataFrame(
-    [(1, "2022-01-01 00:00:00")], ["id", "my_column"]
-)
+input_df = spark.createDataFrame([(1, "2022-01-01 00:00:00")], ["id", "my_column"])
 
 # add 1 day to my_column and store the result in a new column called 'one_day_later'
-output_df = DateTimeAddInterval(
-    column="my_column", target_column="one_day_later", interval="1 day"
-).transform(input_df)
+output_df = DateTimeAddInterval(column="my_column", target_column="one_day_later", interval="1 day").transform(input_df)
 ```
 __output_df__:
 

--- a/src/koheesio/spark/transformations/lookup.py
+++ b/src/koheesio/spark/transformations/lookup.py
@@ -103,9 +103,7 @@ class DataframeLookup(Transformation):
         df=left_df,
         other=right_df,
         on=JoinMapping(source_column="id", joined_column="id"),
-        targets=TargetColumn(
-            target_column="value", target_column_alias="right_value"
-        ),
+        targets=TargetColumn(target_column="value", target_column_alias="right_value"),
         how=JoinType.LEFT,
     )
 

--- a/src/koheesio/spark/transformations/strings/change_case.py
+++ b/src/koheesio/spark/transformations/strings/change_case.py
@@ -51,9 +51,7 @@ class LowerCase(ColumnsTransformationWithTarget):
     |              Beans|  1600|    USA|
 
     ```python
-    output_df = LowerCase(
-        column="product", target_column="product_lower"
-    ).transform(df)
+    output_df = LowerCase(column="product", target_column="product_lower").transform(df)
     ```
 
     __output_df:__
@@ -109,9 +107,7 @@ class UpperCase(LowerCase):
     |              Beans|  1600|    USA|
 
     ```python
-    output_df = UpperCase(
-        column="product", target_column="product_upper"
-    ).transform(df)
+    output_df = UpperCase(column="product", target_column="product_upper").transform(df)
     ```
 
     __output_df:__
@@ -162,9 +158,7 @@ class TitleCase(LowerCase):
     |              Beans|  1600|    USA|
 
     ```python
-    output_df = TitleCase(
-        column="product", target_column="product_title"
-    ).transform(df)
+    output_df = TitleCase(column="product", target_column="product_title").transform(df)
     ```
 
     __output_df:__

--- a/src/koheesio/spark/transformations/strings/split.py
+++ b/src/koheesio/spark/transformations/strings/split.py
@@ -51,9 +51,7 @@ class SplitAll(ColumnsTransformationWithTarget):
     |              Beans|  1600|    USA|
 
     ```python
-    output_df = SplitColumn(
-        column="product", target_column="split", split_pattern=" "
-    ).transform(input_df)
+    output_df = SplitColumn(column="product", target_column="split", split_pattern=" ").transform(input_df)
     ```
 
     __output_df:__
@@ -109,9 +107,7 @@ class SplitAtFirstMatch(SplitAll):
     |              Beans|  1600|    USA|
 
     ```python
-    output_df = SplitColumn(
-        column="product", target_column="split_first", split_pattern="an"
-    ).transform(input_df)
+    output_df = SplitColumn(column="product", target_column="split_first", split_pattern="an").transform(input_df)
     ```
 
     __output_df:__

--- a/src/koheesio/spark/transformations/strings/trim.py
+++ b/src/koheesio/spark/transformations/strings/trim.py
@@ -57,9 +57,7 @@ class Trim(ColumnsTransformationWithTarget):
     ### Trim whitespace from the beginning of a string
 
     ```python
-    output_df = Trim(
-        column="column", target_column="trimmed_column", direction="left"
-    ).transform(input_df)
+    output_df = Trim(column="column", target_column="trimmed_column", direction="left").transform(input_df)
     ```
 
     __output_df:__
@@ -86,9 +84,7 @@ class Trim(ColumnsTransformationWithTarget):
     ### Trim whitespace from the end of a string
 
     ```python
-    output_df = Trim(
-        column="column", target_column="trimmed_column", direction="right"
-    ).transform(input_df)
+    output_df = Trim(column="column", target_column="trimmed_column", direction="right").transform(input_df)
     ```
 
     __output_df:__

--- a/src/koheesio/spark/transformations/uuid5.py
+++ b/src/koheesio/spark/transformations/uuid5.py
@@ -110,9 +110,7 @@ class HashUUID5(Transformation):
 
     In code:
     ```python
-    HashUUID5(source_columns=["id", "string"], target_column="uuid5").transform(
-        input_df
-    )
+    HashUUID5(source_columns=["id", "string"], target_column="uuid5").transform(input_df)
     ```
 
     In this example, the `id` and `string` columns are concatenated and hashed using the UUID5 algorithm. The result is

--- a/src/koheesio/spark/writers/file_writer.py
+++ b/src/koheesio/spark/writers/file_writer.py
@@ -141,9 +141,7 @@ class AvroFileWriter(FileWriter):
     Examples
     --------
     ```python
-    writer = AvroFileWriter(
-        df=df, path="path/to/file.avro", output_mode=BatchOutputMode.APPEND
-    )
+    writer = AvroFileWriter(df=df, path="path/to/file.avro", output_mode=BatchOutputMode.APPEND)
     ```
     """
 
@@ -160,9 +158,7 @@ class JsonFileWriter(FileWriter):
     Examples
     --------
     ```python
-    writer = JsonFileWriter(
-        df=df, path="path/to/file.json", output_mode=BatchOutputMode.APPEND
-    )
+    writer = JsonFileWriter(df=df, path="path/to/file.json", output_mode=BatchOutputMode.APPEND)
     ```
     """
 
@@ -179,9 +175,7 @@ class OrcFileWriter(FileWriter):
     Examples
     --------
     ```python
-    writer = OrcFileWriter(
-        df=df, path="path/to/file.orc", output_mode=BatchOutputMode.APPEND
-    )
+    writer = OrcFileWriter(df=df, path="path/to/file.orc", output_mode=BatchOutputMode.APPEND)
     ```
     """
 
@@ -198,9 +192,7 @@ class TextFileWriter(FileWriter):
     Examples
     --------
     ```python
-    writer = TextFileWriter(
-        df=df, path="path/to/file.txt", output_mode=BatchOutputMode.APPEND
-    )
+    writer = TextFileWriter(df=df, path="path/to/file.txt", output_mode=BatchOutputMode.APPEND)
     ```
     """
 

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -72,12 +72,13 @@ class StepMetaClass(ModelMetaclass):
     allowing for the execute method to be auto-decorated with do_execute
     """
 
-    # Solution to overcome issue with python>=3.11,
-    # When partialmethod is forgetting that _execute_wrapper
-    # is a method of wrapper, and it needs to pass that in as the first arg.
-    # https://github.com/python/cpython/issues/99152
     # noinspection PyPep8Naming,PyUnresolvedReferences
     class _partialmethod_with_self(partialmethod):
+        """Solution to overcome issue with python>=3.11, when partialmethod is forgetting that _execute_wrapper is a
+        method of wrapper, and it needs to pass that in as the first arg.
+        See: https://github.com/python/cpython/issues/99152
+        """
+
         def __get__(self, obj: Any, cls=None):  # type: ignore[no-untyped-def]
             return self._make_unbound_method().__get__(obj, cls)
 

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -134,44 +134,43 @@ class StepMetaClass(ModelMetaclass):
             **kwargs,
         )
 
-        # Extract execute method present in the class
-        execute_method = getattr(cls, "execute")
+        # Traverse the MRO to find the first occurrence of the execute method
+        execute_method = None
+        for base in cls.__mro__:
+            if "execute" in base.__dict__:
+                execute_method = base.__dict__["execute"]
+                break
 
-        # check if function is already wrapped with do_execute
-        # Here we are trying to get the attribute "_partialmethod__step_execute_wrapper_sentinel"
-        # from the execute_method function.
-        # If the function is already wrapped, this attribute should exist.
-        sentinel = getattr(execute_method, "_partialmethod__step_execute_wrapper_sentinel", None)
+        if execute_method:
+            # Check if the execute method is already wrapped
+            is_already_wrapped = (
+                getattr(execute_method, "_step_execute_wrapper_sentinel", None) is cls._step_execute_wrapper_sentinel
+            )
 
-        # Check if the sentinel is the same as the class's sentinel. If they are the same,
-        # it means the function is already wrapped.
-        # noinspection PyUnresolvedReferences
-        is_already_wrapped = sentinel is cls._step_execute_wrapper_sentinel
+            # Get the wrap count of the function. If the function is not wrapped yet, the default value is 0.
+            wrap_count = getattr(execute_method, "_wrap_count", 0)
 
-        # Get the wrap count of the function. If the function is not wrapped yet, the default value is 0.
-        wrap_count = getattr(execute_method, "_partialmethod_wrap_count", 0)
+            # prevent multiple wrapping
+            # If the function is not already wrapped, we proceed to wrap it.
+            if not is_already_wrapped:
+                # Create a partial method with the execute_method as one of the arguments.
+                # This is the new function that will be called instead of the original execute_method.
 
-        # prevent multiple wrapping
-        # If the function is not already wrapped, we proceed to wrap it.
-        if not is_already_wrapped:
-            # Create a partial method with the execute_method as one of the arguments.
-            # This is the new function that will be called instead of the original execute_method.
+                # noinspection PyProtectedMember,PyUnresolvedReferences
+                wrapper = mcs._partialmethod_impl(cls=cls, execute_method=execute_method)
 
-            # noinspection PyProtectedMember,PyUnresolvedReferences
-            wrapper = mcs._partialmethod_impl(cls=cls, execute_method=execute_method)
+                # Updating the attributes of the wrapping function to those of the original function.
+                wraps(execute_method)(wrapper)  # type: ignore
 
-            # Updating the attributes of the wrapping function to those of the original function.
-            wraps(execute_method)(wrapper)  # type: ignore
+                # Set the sentinel attribute to the wrapper. This is done so that we can check
+                # if the function is already wrapped.
+                # noinspection PyUnresolvedReferences
+                setattr(wrapper, "_step_execute_wrapper_sentinel", cls._step_execute_wrapper_sentinel)
 
-            # Set the sentinel attribute to the wrapper. This is done so that we can check
-            # if the function is already wrapped.
-            # noinspection PyUnresolvedReferences
-            setattr(wrapper, "_step_execute_wrapper_sentinel", cls._step_execute_wrapper_sentinel)
-
-            # Increase the wrap count of the function. This is done to keep track of
-            # how many times the function has been wrapped.
-            setattr(wrapper, "_wrap_count", wrap_count + 1)
-            setattr(cls, "execute", wrapper)
+                # Increase the wrap count of the function. This is done to keep track of
+                # how many times the function has been wrapped.
+                setattr(wrapper, "_wrap_count", wrap_count + 1)
+                setattr(cls, "execute", wrapper)
 
         return cls
 

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import wraps
-import inspect
 import io
 from unittest import mock
 from unittest.mock import call, patch
@@ -12,7 +11,6 @@ import pytest
 
 from pydantic import ValidationError
 
-from koheesio import LoggingFactory
 from koheesio.models import Field
 from koheesio.steps import Step, StepMetaClass, StepOutput
 from koheesio.steps.dummy import DummyOutput, DummyStep

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import wraps
+import inspect
 import io
 from unittest import mock
 from unittest.mock import call, patch
@@ -11,6 +12,7 @@ import pytest
 
 from pydantic import ValidationError
 
+from koheesio import LoggingFactory
 from koheesio.models import Field
 from koheesio.steps import Step, StepMetaClass, StepOutput
 from koheesio.steps.dummy import DummyOutput, DummyStep
@@ -31,7 +33,10 @@ PROJECT_ROOT = get_project_root()
 
 
 class TestStepOutput:
-    @pytest.mark.parametrize("output_dict, expected", [(output_dict_1, output_dict_1), (output_dict_2, output_dict_2)])
+    @pytest.mark.parametrize(
+        "output_dict, expected",
+        [(output_dict_1, output_dict_1), (output_dict_2, output_dict_2)],
+    )
     def test_stepoutput_validate_output(self, output_dict, expected):
         """Tests that validate_output returns the expected output dict"""
         test_output = DummyOutput(**output_dict)
@@ -59,7 +64,12 @@ class TestStepOutput:
             (
                 "foo",
                 42,
-                {"a": "foo", "b": 42, "name": "DummyOutput", "description": "Dummy output for testing purposes."},
+                {
+                    "a": "foo",
+                    "b": 42,
+                    "name": "DummyOutput",
+                    "description": "Dummy output for testing purposes.",
+                },
             ),
             # test wrong type assigned
             ("foo", "invalid type", ValidationError),
@@ -159,7 +169,9 @@ class TestStep:
 
         assert step.model_dump() == dict(a="foo", description="SimpleStep", name="SimpleStep")
         assert step.execute().model_dump() == dict(
-            b="foo-some-suffix", name="SimpleStep.Output", description="Output for SimpleStep"
+            b="foo-some-suffix",
+            name="SimpleStep.Output",
+            description="Output for SimpleStep",
         )
 
         # as long as the following doesn't raise an error, we're good
@@ -180,9 +192,7 @@ class TestStep:
             b=2,
             c="foofoo",
         )
-        print(f"{actual_execute=}")
-        print(f"{actual_run=}")
-        print(f"{expected=}")
+
         assert actual_execute == actual_run == expected
 
         # 3 ways to retrieve output
@@ -283,7 +293,11 @@ class TestStep:
 
         # Check that do_execute was not called multiple times
         assert (
-            getattr(getattr(obj.execute, "_partialmethod", None), "_step_execute_wrapper_sentinel", None)
+            getattr(
+                getattr(obj.execute, "_partialmethod", None),
+                "_step_execute_wrapper_sentinel",
+                None,
+            )
             is StepMetaClass._step_execute_wrapper_sentinel
         )
         assert getattr(getattr(obj.execute, "_partialmethod", None), "_wrap_count", 0) == 1
@@ -345,6 +359,51 @@ class TestStep:
 
             assert "It's me from custom meta class" in print_output
 
+    def test_log_and_wrapper_duplication(self):
+        """
+        Test that when a step is inherited multiple times, the log and wrapper are only called once when subclasses do
+        not have explicit execute methods set.
+        """
+
+        class MyCustomParentStep(Step):
+            foo: str = Field(default=..., description="Foo")
+            bar: str = Field(default=..., description="Bar")
+
+            class Output(Step.Output):
+                baz: str = Field(default=..., description="Baz")
+
+            def execute(self) -> Output:
+                self.log.error("This should not be logged")
+                self.output.baz = self.foo + self.bar
+
+        class MyCustomChildStep(MyCustomParentStep): ...
+
+        class MyCustomGrandChildStep(MyCustomChildStep):
+            def execute(self) -> MyCustomChildStep.Output:
+                self.output.baz = self.foo + self.bar
+
+        class MyCustomGreatGrandChildStep(MyCustomGrandChildStep): ...
+
+        with (
+            patch.object(MyCustomGreatGrandChildStep, "log", autospec=True) as mock_log,
+        ):
+            obj = MyCustomGreatGrandChildStep(foo="foo", bar="bar", qux="qux")
+            obj.execute()
+
+            name = MyCustomGreatGrandChildStep.__name__
+
+            # Check that logs were called once (and only once) with the correct messages, and in the correct order
+            calls = [
+                call.info("Start running step"),
+                call.debug(f"Step Input: name='{name}' description='{name}' foo='foo' bar='bar' qux='qux'"),
+                call.debug(f"Step Output: name='{name}.Output' description='Output for {name}' baz='foobar'"),
+                call.info("Finished running step"),
+            ]
+            mock_log.assert_has_calls(calls, any_order=False)
+
+            # Check that the execute method is only wrapped once
+            assert getattr(getattr(obj.execute, "_partialmethod", None), "_wrap_count", 0) == 1
+
     @pytest.mark.parametrize("test_class", [YourClassWithCustomMeta2])
     def test_custom_metaclass_output(self, test_class):
         with patch.object(test_class, "log", autospec=True) as mock_log:
@@ -381,6 +440,7 @@ class TestStep:
                 call.debug(f"Step Output: name='{name}.Output' description='Output for {name}'"),
                 call.info("Finished running step"),
             ]
+            print(f"{mock_log.mock_calls = }")
             mock_log.assert_has_calls(calls, any_order=False)
 
     def test_output_validation(self):

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -92,7 +92,6 @@ class TestStepOutput:
                     lazy_output.validate_output()
             else:
                 actual = lazy_output.validate_output().model_dump()
-                print(f"{actual=}")
                 assert actual == expected
 
     @pytest.mark.parametrize("attribute, expected", [("a", True), ("d", False)])
@@ -440,7 +439,6 @@ class TestStep:
                 call.debug(f"Step Output: name='{name}.Output' description='Output for {name}'"),
                 call.info("Finished running step"),
             ]
-            print(f"{mock_log.mock_calls = }")
             mock_log.assert_has_calls(calls, any_order=False)
 
     def test_output_validation(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enhanced the Step class and its metaclass StepMetaClass to ensure that the execute method is wrapped only once, even when inherited multiple times. Added tests to verify that the log and wrapper are called only once in such scenarios. Also, included custom metaclass examples and their respective tests.  

## Related Issue
N/A

## Motivation and Context
It was established that (under the right conditions) our code allowed the execute method to be wrapped multiple times, even though we had code in place to prevent that. This reflected outwardly by seeing log duplication. For example like this:

#### Wrong output:
```bash
    [1111] [2024-11-18 14:22:18,355] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:307} - Start running step
    [1111] [2024-11-18 14:22:18,355] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:308} - Step Input: name='MyCustomGreatGrandChildStep' description='MyCustomGreatGrandChildStep' foo='foo' bar='bar' qux='qux'
    [1111] [2024-11-18 14:22:18,355] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:307} - Start running step
    [1111] [2024-11-18 14:22:18,355] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:308} - Step Input: name='MyCustomGreatGrandChildStep' description='MyCustomGreatGrandChildStep' foo='foo' bar='bar' qux='qux'
    [1111] [2024-11-18 14:22:18,355] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:307} - Start running step
    [1111] [2024-11-18 14:22:18,355] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:308} - Step Input: name='MyCustomGreatGrandChildStep' description='MyCustomGreatGrandChildStep' foo='foo' bar='bar' qux='qux'
    [1111] [2024-11-18 14:22:18,356] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:329} - Step Output: name='MyCustomGreatGrandChildStep.Output' description='Output for MyCustomGreatGrandChildStep' baz='foobar'
    [1111] [2024-11-18 14:22:18,356] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:330} - Finished running step
    [1111] [2024-11-18 14:22:18,356] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:329} - Step Output: name='MyCustomGreatGrandChildStep.Output' description='Output for MyCustomGreatGrandChildStep' baz='foobar'
    [1111] [2024-11-18 14:22:18,356] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:330} - Finished running step
    [1111] [2024-11-18 14:22:18,356] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:329} - Step Output: name='MyCustomGreatGrandChildStep.Output' description='Output for MyCustomGreatGrandChildStep' baz='foobar'
    [1111] [2024-11-18 14:22:18,356] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:330} - Finished running step
```

#### Expected output:
```bash
    [1111] [2024-11-18 14:22:18,355] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:307} - Start running step
    [1111] [2024-11-18 14:22:18,355] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_start_message:308} - Step Input: name='MyCustomGreatGrandChildStep' description='MyCustomGreatGrandChildStep' foo='foo' bar='bar' qux='qux'
    [1111] [2024-11-18 14:22:18,356] [DEBUG] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:329} - Step Output: name='MyCustomGreatGrandChildStep.Output' description='Output for MyCustomGreatGrandChildStep' baz='foobar'
    [1111] [2024-11-18 14:22:18,356] [INFO] [koheesio.MyCustomGreatGrandChildStep] {__init__.py:_log_end_message:330} - Finished running step
```

## How Has This Been Tested?
Tested by adding unit tests in tests/steps/test_steps.py to verify that the execute method is wrapped only once and that the log messages are called in the correct order. The tests also cover custom metaclass functionality and ensure that the output validation and logging work as expected.

## Screenshots (if appropriate):
...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
