### PR TITLE
[FEATURE] Enable adding options to DeltaReader both streaming and writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ out/**
 
 # DevContainer
 .devcontainer
+uv.lock

--- a/src/koheesio/spark/readers/delta.py
+++ b/src/koheesio/spark/readers/delta.py
@@ -165,7 +165,7 @@ class DeltaTableReader(Reader):
 
     # private attrs
     __temp_view_name__: Optional[str] = None
-    __reader: Optional[DataStreamReader] = PrivateAttr(default=None)
+    __reader: Optional[Union[DataStreamReader, DataFrameReader]] = PrivateAttr(default=None)
 
     @property
     def temp_view_name(self) -> str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introduce private attributes for batch and stream readers to enable adding options to DeltaReader both streaming and writing.

## Related Issue
#110 

## Motivation and Context
Provide possibility to override readers, e.g. add more options to readers. 

## How Has This Been Tested?
Current tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
