### PR TITLE
[FEATURE] Populate account from url if not provided in SnowflakeBaseModel

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -4,6 +4,8 @@ from unittest import mock
 
 import pytest
 
+from pydantic import ValidationError
+
 from koheesio.integrations.snowflake import (
     GrantPrivilegesOnObject,
     GrantPrivilegesOnTable,
@@ -119,6 +121,15 @@ class TestSnowflakeRunQueryPython:
         }
         assert actual_options == expected_options
         assert query_in_options["query"] == expected_query, "query should be returned regardless of the input"
+
+    def test_mandatory_fields(self):
+        """Test that query and account fields are mandatory"""
+        with pytest.raises(ValidationError):
+            _1 = SnowflakeRunQueryPython(**COMMON_OPTIONS)
+
+        # sql/query and account should work without raising an error
+        _2 = SnowflakeRunQueryPython(**COMMON_OPTIONS, sql="SELECT foo", account="42")
+        _3 = SnowflakeRunQueryPython(**COMMON_OPTIONS, query="SELECT foo", account="42")
 
     def test_account_populated_from_url(self):
         kls = SnowflakeRunQueryPython(**COMMON_OPTIONS, sql="SELECT * FROM table")

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -98,6 +98,15 @@ class TestGrantPrivilegesOnView:
 
 
 class TestSnowflakeRunQueryPython:
+    def test_mandatory_fields(self):
+        """Test that query and account fields are mandatory"""
+        with pytest.raises(ValidationError):
+            _1 = SnowflakeRunQueryPython(**COMMON_OPTIONS)
+
+        # sql/query and account should work without raising an error
+        _2 = SnowflakeRunQueryPython(**COMMON_OPTIONS, sql="SELECT foo", account="42")
+        _3 = SnowflakeRunQueryPython(**COMMON_OPTIONS, query="SELECT foo", account="42")
+
     def test_get_options(self):
         """Test that the options are correctly generated"""
         # Arrange
@@ -121,15 +130,6 @@ class TestSnowflakeRunQueryPython:
         }
         assert actual_options == expected_options
         assert query_in_options["query"] == expected_query, "query should be returned regardless of the input"
-
-    def test_mandatory_fields(self):
-        """Test that query and account fields are mandatory"""
-        with pytest.raises(ValidationError):
-            _1 = SnowflakeRunQueryPython(**COMMON_OPTIONS)
-
-        # sql/query and account should work without raising an error
-        _2 = SnowflakeRunQueryPython(**COMMON_OPTIONS, sql="SELECT foo", account="42")
-        _3 = SnowflakeRunQueryPython(**COMMON_OPTIONS, query="SELECT foo", account="42")
 
     def test_account_populated_from_url(self):
         kls = SnowflakeRunQueryPython(**COMMON_OPTIONS, sql="SELECT * FROM table")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Populate account from url if not provided in SnowflakeBaseModel

## Related Issue
#115 

## Motivation and Context
Account populated from url if not provided

## How Has This Been Tested?
New tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
