### PR TITLE
[BUGFIX] ColumnConfig defaults in ColumnsTransformation for run_for_all_data_type and limit_data_type were not working correctly

### DIFF
--- a/src/koheesio/spark/transformations/__init__.py
+++ b/src/koheesio/spark/transformations/__init__.py
@@ -461,14 +461,16 @@ class ColumnsTransformation(Transformation, ABC):
 
     def get_columns(self) -> Iterator[str]:
         """Return an iterator of the columns"""
+        columns = self.columns or self.df.columns
+
         # If `run_for_all_is_set` to True, we want to run the transformation for all columns of a given type,
         # unless the user has specified specific columns
-        columns = self.columns or []  # type:ignore[assignment]
-
-        if self.run_for_all_is_set and columns[0] == "*":
-            columns = []
-            for data_type in self.ColumnConfig.run_for_all_data_type:  # type: ignore
-                columns += self.get_all_columns_of_specific_type(data_type)
+        if self.run_for_all_is_set and (not columns or columns[0] == "*"):
+            columns = [
+                col
+                for data_type in self.ColumnConfig.run_for_all_data_type  # type: ignore
+                for col in self.get_all_columns_of_specific_type(data_type)
+            ]
 
         for column in columns:
             if self.is_column_type_correct(column):

--- a/src/koheesio/spark/transformations/__init__.py
+++ b/src/koheesio/spark/transformations/__init__.py
@@ -27,9 +27,9 @@ from abc import ABC, abstractmethod
 from pyspark.sql import functions as f
 from pyspark.sql.types import DataType
 
-from koheesio.models import Field, ListOfColumns, field_validator
+from koheesio.models import Field, ListOfColumns, model_validator
 from koheesio.spark import Column, DataFrame, SparkStep
-from koheesio.spark.utils import SparkDatatype
+from koheesio.spark.utils import SparkDatatype, get_column_name
 
 
 class Transformation(SparkStep, ABC):
@@ -293,36 +293,39 @@ class ColumnsTransformation(Transformation, ABC):
             (default: False)
         """
 
-        run_for_all_data_type: Optional[List[SparkDatatype]] = [None]  # type: ignore
-        limit_data_type: Optional[List[SparkDatatype]] = [None]
+        run_for_all_data_type: Optional[List[SparkDatatype]] = None
+        limit_data_type: Optional[List[SparkDatatype]] = None
         data_type_strict_mode: bool = False
 
-    @field_validator("columns", mode="before")
-    def set_columns(cls, columns_value: ListOfColumns) -> ListOfColumns:
+    @model_validator(mode="after")
+    def set_columns(self) -> "ColumnsTransformation":
         """Validate columns through the columns configuration provided"""
-        columns = columns_value
-        run_for_all_data_type = cls.ColumnConfig.run_for_all_data_type
+        columns = self.columns
 
-        if run_for_all_data_type and len(columns) == 0:
-            columns = ["*"]
+        if len(columns) == 0:
+            if self.run_for_all_is_set:
+                columns = ["*"]
+        else:
+            if columns[0] == "*" and not self.run_for_all_is_set:
+                raise ValueError("Cannot use '*' as a column name when no run_for_all_data_type is set")
 
-        if columns[0] == "*" and not run_for_all_data_type:
-            raise ValueError("Cannot use '*' as a column name when no run_for_all_data_type is set")
+        self.columns = columns
+        return self
 
-        return columns
-
+    @classmethod
     @property
-    def run_for_all_is_set(self) -> bool:
+    def run_for_all_is_set(cls) -> bool:
         """Returns True if the transformation should be run for all columns of a given type"""
-        run_for_all_data_type = self.ColumnConfig.run_for_all_data_type
-        if run_for_all_data_type and self.columns[0] == "*":
-            return True
-        return False
+        rfadt = cls.ColumnConfig.run_for_all_data_type  # shorthand
+        return bool(rfadt and isinstance(rfadt, list) and rfadt[0] is not None)
 
+    @classmethod
     @property
-    def limit_data_type_is_set(self) -> bool:
+    def limit_data_type_is_set(cls) -> bool:
         """Returns True if limit_data_type is set"""
-        return self.ColumnConfig.limit_data_type[0] is not None  # type: ignore[index]
+        if (limit_data_type := cls.ColumnConfig.limit_data_type) is not None:
+            return limit_data_type[0] is not None  # type: ignore
+        return False
 
     @property
     def data_type_strict_mode_is_set(self) -> bool:
@@ -368,10 +371,10 @@ class ColumnsTransformation(Transformation, ABC):
             The column to check the type of
 
         df : Optional[DataFrame]
-            The DataFrame belonging to the column. If not provided, the DataFrame passed to the constructor
-            will be used.
+            The DataFrame belonging to the column. If not provided, the DataFrame passed to the constructor will be
+            used.
 
-        simple_return_mode : bool
+        simple_return_mode : bool, default=True
             If True, the return value will be a simple string. If False, the return value will be a SparkDatatype enum.
 
         Returns
@@ -383,18 +386,17 @@ class ColumnsTransformation(Transformation, ABC):
         if not df:
             raise RuntimeError("No valid Dataframe was passed")
 
+        # ensure that the column is a Column object
         if not isinstance(col, Column):  # type:ignore[misc, arg-type]
             col = f.col(col)  # type:ignore[arg-type]
-
-        # noinspection PyProtectedMember,PyUnresolvedReferences
-        col_name = (
-            col._expr._unparsed_identifier
-            if col.__class__.__module__ == "pyspark.sql.connect.column"
-            else col._jc.toString()  # type: ignore  # noqa: E721
-        )
+        col_name = get_column_name(col)
 
         # In order to check the datatype of the column, we have to ask the DataFrame its schema
-        df_col = [c for c in df.schema if c.name == col_name][0]
+        df_col = next((c for c in df.schema if c.name == col_name), None)
+
+        # Check if the column exists in the DataFrame schema
+        if df_col is None:
+            raise ValueError(f"Column '{col_name}' does not exist in the DataFrame schema")
 
         if simple_return_mode:
             return SparkDatatype(df_col.dataType.typeName()).value
@@ -428,6 +430,10 @@ class ColumnsTransformation(Transformation, ABC):
         columns_of_given_type: List[str] = [
             col for col in self.df.columns if self.df.schema[col].dataType.typeName() == expected_data_type
         ]
+
+        if not columns_of_given_type:
+            self.log.warning(f"No columns of type '{expected_data_type}' found in the DataFrame")
+
         return columns_of_given_type
 
     def is_column_type_correct(self, column: Union[Column, str]) -> bool:
@@ -455,13 +461,14 @@ class ColumnsTransformation(Transformation, ABC):
 
     def get_columns(self) -> Iterator[str]:
         """Return an iterator of the columns"""
-        # If `run_for_all_is_set` is True, we want to run the transformation for all columns of a given type
-        if self.run_for_all_is_set:
+        # If `run_for_all_is_set` to True, we want to run the transformation for all columns of a given type,
+        # unless the user has specified specific columns
+        columns = self.columns or []  # type:ignore[assignment]
+
+        if self.run_for_all_is_set and columns[0] == "*":
             columns = []
             for data_type in self.ColumnConfig.run_for_all_data_type:  # type: ignore
                 columns += self.get_all_columns_of_specific_type(data_type)
-        else:
-            columns = self.columns  # type:ignore[assignment]
 
         for column in columns:
             if self.is_column_type_correct(column):

--- a/tests/spark/transformations/test_transform.py
+++ b/tests/spark/transformations/test_transform.py
@@ -6,9 +6,9 @@ from pyspark.sql import functions as f
 
 from koheesio.logger import LoggingFactory
 from koheesio.spark import DataFrame
+from koheesio.spark.transformations.hash import Sha2Hash
 from koheesio.spark.transformations.strings.substring import Substring
 from koheesio.spark.transformations.transform import Transform
-from koheesio.spark.transformations.hash import Sha2Hash
 
 pytestmark = pytest.mark.spark
 
@@ -88,7 +88,6 @@ def test_from_func(dummy_df):
 
 
 def test_df_transform_compatibility(dummy_df: DataFrame):
-
     expected_data = {
         "id": 0,
         "foo": "bar",

--- a/tests/spark/transformations/test_transformation.py
+++ b/tests/spark/transformations/test_transformation.py
@@ -199,3 +199,13 @@ class TestColumnsTransformationDataTypeLimitations:
         actual = [col for col in multiple_data_types.get_columns()]
         expected = ["str_column", "long_column"]
         assert sorted(actual) == sorted(expected)
+
+    def test_column_does_not_exist(self, str_long_df):
+        class TestTransformation(ColumnsTransformation):
+            def execute(self):
+                pass
+
+        tf = TestTransformation(columns=["non_existent_column"], df=str_long_df)
+
+        with pytest.raises(ValueError, match="Column 'non_existent_column' does not exist in the DataFrame schema"):
+            tf.column_type_of_col("non_existent_column")

--- a/tests/spark/transformations/test_transformation.py
+++ b/tests/spark/transformations/test_transformation.py
@@ -111,7 +111,7 @@ class TestColumnsTransformationDataTypeLimitations:
         )
 
         # we should get None on run_for_all_is_set since we have specified columns
-        assert add_two.run_for_all_is_set is False
+        assert add_two.run_for_all_is_set is True
         assert add_two.ColumnConfig.run_for_all_data_type == [SparkDatatype.LONG]
 
         assert add_two.limit_data_type_is_set is True
@@ -124,6 +124,7 @@ class TestColumnsTransformationDataTypeLimitations:
         assert columns == ["long_column"]
 
     def test_strict_config_with_columns_unhappy(self, str_long_df):
+        """Passing a column with a 'wrong' datatype should raise a ValueError when strict mode is enabled"""
         # explicitly pass a value for columns
         add_two = self.AddTwoStrict(
             columns=["str_column"],


### PR DESCRIPTION
Fix ColumnConfig in ColumnsTransformation
- ColumnConfig defaults in ColumnsTransformation for run_for_all_data_type and limit_data_type were not working correctly

+ Added more efficient Spark 3.4 supported operation for CamelToSnakeTransformation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#85 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
