### PR TITLE
[FEATURE] add partial method to BaseModel

### DIFF
--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -20,12 +20,26 @@ class TestBaseModel:
         foo: Optional[str] = None
         baz: Optional[int] = None
 
+    def test_partial(self) -> None:
+        """Test BaseModel's partial method"""
+        # Arrange
+        partial_model = self.SimpleModel.partial(a=42, b="baz")
+        # Act
+        model_standard = partial_model()
+        model_with_overwrite = partial_model(b="bla")
+        # Assert
+        assert model_standard.a == 42
+        assert model_standard.b == "baz"
+        assert model_with_overwrite.a == 42
+        assert model_with_overwrite.b == "bla"
+
     def test_a_simple_model(self) -> None:
         """Test a simple model."""
         foo = self.SimpleModel(a=1)
         assert foo.model_dump() == {"a": 1, "b": "default", "description": "SimpleModel", "name": "SimpleModel"}
 
     def test_context_management_no_exception(self) -> None:
+        """Test that with-statement works without throwing exceptions"""
         with self.SimpleModel.lazy() as m:
             m.a = 1
             m.b = "test"

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,3 +1,5 @@
+"""Test suite for Koheesio's extended BaseModel class"""
+
 from typing import Optional
 import json
 from textwrap import dedent
@@ -18,19 +20,19 @@ class TestBaseModel:
         foo: Optional[str] = None
         baz: Optional[int] = None
 
-    def test_a_simple_model(self):
+    def test_a_simple_model(self) -> None:
         """Test a simple model."""
         foo = self.SimpleModel(a=1)
         assert foo.model_dump() == {"a": 1, "b": "default", "description": "SimpleModel", "name": "SimpleModel"}
 
-    def test_context_management_no_exception(self):
+    def test_context_management_no_exception(self) -> None:
         with self.SimpleModel.lazy() as m:
             m.a = 1
             m.b = "test"
         assert m.a == 1
         assert m.b == "test"
 
-    def test_context_management_with_exception(self):
+    def test_context_management_with_exception(self) -> None:
         """The context manager should raise the original exception after exiting the context."""
         with pytest.raises(ValueError):
             with self.SimpleModel.lazy() as m:
@@ -42,10 +44,10 @@ class TestBaseModel:
         assert m.b == "test"
 
     @pytest.fixture(params=[{"foo": "bar"}, {"baz": 123}, {"foo": "bar", "baz": 123}])
-    def context_data(self, request):
+    def context_data(self, request: pytest.FixtureRequest) -> dict:
         return request.param
 
-    def test_add(self):
+    def test_add(self) -> None:
         model1 = self.SimpleModel(a=1)
         model2 = self.SimpleModel(a=2)
         model = model1 + model2
@@ -53,41 +55,41 @@ class TestBaseModel:
         assert model.a == 2
         assert model.b == "default"
 
-    def test_getitem(self):
+    def test_getitem(self) -> None:
         model = self.SimpleModel(a=1)
         assert model["a"] == 1
 
-    def test_setitem(self):
+    def test_setitem(self) -> None:
         model = self.SimpleModel(a=1)
         model["a"] = 2
         assert model.a == 2
 
-    def test_hasattr(self):
+    def test_hasattr(self) -> None:
         model = self.SimpleModel(a=1)
         assert model.hasattr("a")
         assert not model.hasattr("non_existent_key")
 
-    def test_from_context(self, context_data):
+    def test_from_context(self, context_data: pytest.FixtureRequest) -> None:
         context = Context(context_data)
         model = self.FooModel.from_context(context)
         assert isinstance(model, BaseModel)
         for key, value in context_data.items():
             assert getattr(model, key) == value
 
-    def test_from_dict(self, context_data):
+    def test_from_dict(self, context_data: pytest.FixtureRequest) ->  None:
         model = self.FooModel.from_dict(context_data)
         assert isinstance(model, BaseModel)
         for key, value in context_data.items():
             assert getattr(model, key) == value
 
-    def test_from_json(self, context_data):
+    def test_from_json(self, context_data: pytest.FixtureRequest) -> None:
         json_data = json.dumps(context_data)
         model = self.FooModel.from_json(json_data)
         assert isinstance(model, BaseModel)
         for key, value in context_data.items():
             assert getattr(model, key) == value
 
-    def test_from_toml(self):
+    def test_from_toml(self) -> None:
         toml_data = dedent(
             """
             a = 1
@@ -99,35 +101,35 @@ class TestBaseModel:
         assert model.a == 1
         assert model.b == "default"
 
-    def test_from_yaml(self, context_data):
+    def test_from_yaml(self, context_data: pytest.FixtureRequest) -> None:
         yaml_data = yaml.dump(context_data)
         model = self.FooModel.from_yaml(yaml_data)
         assert isinstance(model, BaseModel)
         for key, value in context_data.items():
             assert getattr(model, key) == value
 
-    def test_to_context(self):
+    def test_to_context(self) -> None:
         model = self.SimpleModel(a=1)
         context = model.to_context()
         assert isinstance(context, Context)
         assert context.a == 1
         assert context.b == "default"
 
-    def test_to_dict(self):
+    def test_to_dict(self) -> None:
         model = self.SimpleModel(a=1)
         dict_model = model.to_dict()
         assert isinstance(dict_model, dict)
         assert dict_model["a"] == 1
         assert dict_model["b"] == "default"
 
-    def test_to_json(self):
+    def test_to_json(self) -> None:
         model = self.SimpleModel(a=1)
         json_model = model.to_json()
         assert isinstance(json_model, str)
         assert '"a": 1' in json_model
         assert '"b": "default"' in json_model
 
-    def test_to_yaml(self):
+    def test_to_yaml(self) -> None:
         model = self.SimpleModel(a=1)
         yaml_model = model.to_yaml()
         assert isinstance(yaml_model, str)
@@ -137,7 +139,7 @@ class TestBaseModel:
     import pytest
 
     class ModelWithDescription(BaseModel):
-        a: int = "42"
+        a: int = 42
         description: str = "This is a\nmultiline description"
 
     class ModelWithDocstring(BaseModel):
@@ -145,22 +147,22 @@ class TestBaseModel:
         when no explicit description is provided.
         """
 
-        a: int = "42"
+        a: int = 42
 
     class EmptyLinesShouldBeRemoved(BaseModel):
         """
         Ignore the empty line
         """
 
-        a: int = "42"
+        a: int = 42
 
     class ModelWithNoDescription(BaseModel):
-        a: int = "42"
+        a: int = 42
 
     class IgnoreDocstringIfDescriptionIsProvided(BaseModel):
         """This is a docstring"""
 
-        a: int = "42"
+        a: int = 42
         description: str = "This is a description"
 
     @pytest.mark.parametrize(
@@ -189,16 +191,16 @@ class TestBaseModel:
             ),
         ],
     )
-    def test_name_and_multiline_description(self, model_class, instance_arg, expected):
+    def test_name_and_multiline_description(self, model_class: type[BaseModel], instance_arg: dict, expected: dict) -> None:
         instance = model_class(**instance_arg)
         assert instance.model_dump() == expected
 
     class ModelWithLongDescription(BaseModel):
-        a: int = "42"
+        a: int = 42
         description: str = "This is a very long description. " * 42
 
     class ModelWithLongDescriptionAndNoSpaces(BaseModel):
-        a: int = "42"
+        a: int = 42
         description: str = "ThisIsAVeryLongDescription" * 42
 
     @pytest.mark.parametrize(
@@ -208,7 +210,7 @@ class TestBaseModel:
             (ModelWithLongDescriptionAndNoSpaces, 120, "ThisIsAVeryLongDescription" * 4 + "ThisIsAVeryLo..."),
         ],
     )
-    def test_extremely_long_description(self, model_class, expected_length, expected_description):
+    def test_extremely_long_description(self, model_class: type[BaseModel], expected_length: int, expected_description: str) -> None:
         model = model_class()
         assert len(model.description) == expected_length
         assert model.description == expected_description
@@ -216,7 +218,7 @@ class TestBaseModel:
 
 
 class TestExtraParamsMixin:
-    def test_extra_params_mixin(self):
+    def test_extra_params_mixin(self) -> None:
         class SimpleModelWithExtraParams(BaseModel, ExtraParamsMixin):
             a: int
             b: str = "default"


### PR DESCRIPTION
Add partial classmethod to Koheesio' BaseModel to enhance customization. 

## Description
This update introduces a new partial method to the BaseModel class, allowing developers to override or extend base functionality easily. This change promotes better modularity and flexibility in creating reusable components within the data pipeline framework.

Additionally, fixed any mypy alerts in the files touched.

## Related Issue
N/A

## Motivation and Context
It was always possible to just wrap a BaseModel (or Step) in a `functools.partial` call. With this PR, it brings this functionality straight to the BaseModel class.

## How Has This Been Tested?
Additional Unit Test has been added.

## Example
```python
class SomeStep(BaseModel):
    foo: str
    bar: int

# Create a partial BaseModel with a default value for 'foo'
partial_step = SomeStep.partial(foo="default_foo")

# Instantiate SomeStep with only 'bar' provided, 'foo' will use the default value provided above
some_step = partial_step(bar=42)
print(some_step.foo)  # prints 'default_foo'
print(some_step.bar)  # prints 42

# Instantiate SomeStep with both 'foo' and 'bar' provided, overriding the default value for 'foo'
another_step = partial_step(foo="custom_foo", bar=100)
print(another_step.foo)  # prints 'custom_foo'
print(another_step.bar)  # prints 100
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
