### PR TITLE
[FEATURE] Enhance HttpStep to support bearer token and improve header handling

### DIFF
--- a/src/koheesio/spark/utils/common.py
+++ b/src/koheesio/spark/utils/common.py
@@ -89,7 +89,7 @@ def check_if_pyspark_connect_is_supported() -> bool:
     Raises
     ------
     ImportError
-        If the required modules for Spark Connect (grpcio and protobuf) are not importable while Spark Connect is being 
+        If the required modules for Spark Connect (grpcio and protobuf) are not importable while Spark Connect is being
         accessed.
     """
     # before pyspark 3.4, connect was not supported
@@ -107,7 +107,7 @@ def check_if_pyspark_connect_is_supported() -> bool:
             raise ImportError(
                 "It looks like the required modules for Spark Connect (e.g. grpcio) are not installed. "
                 "If not, you can install them using `pip install pyspark[connect]` or `koheesio[pyspark_connect]`. "
-            )
+            ) from e
 
     return False
 

--- a/src/koheesio/steps/http.py
+++ b/src/koheesio/steps/http.py
@@ -477,24 +477,3 @@ class PaginatedHttpGetStep(HttpGetStep):
         self.output.response_raw = None
         self.output.raw_payload = None
         self.output.status_code = None
-
-
-if __name__ == "__main__":
-
-    class CustomHttpStep(HttpStep):
-        ...
-        # bearer_token: SecretStr
-
-        # def get_headers(self) -> dict:
-        #     """Construct the headers for the API request."""
-        #     self.headers = {
-        #         "Authorization": f"Bearer {self.bearer_token.get_secret_value()}",
-        #         "Content-Type": "application/json",
-        #     }
-        #     return super().get_headers()
-
-    step = CustomHttpStep(
-        url="https://example.com",
-        bearer_token="foo_bar_token",
-        headers={"Content-Type": "application/json"},
-    )

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -151,7 +151,7 @@ def test_get_headers(params):
     converted back to string, otherwise sensitive info would have looked like '**********'.
     """
     # Arrange and Act
-    step = HttpStep(**params).get_headers()
+    step = HttpStep(**params)
 
     # Assert
     actual_headers = step.get_headers()

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -136,15 +136,25 @@ def test_http_step_request():
             assert response.status_code == 200
 
 
-def test_get_headers():
-    # Authorization headers are being converted into SecretStr under the hood to avoid dumping any
-    # sensitive content into logs. However, when calling the `get_headers` method, the SecretStr is being
-    # converted back to string, otherwise sensitive info would have looked like '**********'.
-    actual_headers = HttpStep(
-        url=GET_ENDPOINT,
-        headers={"Authorization": "Bearer token", "Content-Type": "application/json"},
-    ).get_headers()
+@pytest.mark.parametrize(
+    "params",
+    [
+        dict(url=GET_ENDPOINT, headers={"Authorization": "Bearer token", "Content-Type": "application/json"}),
+        dict(url=GET_ENDPOINT, headers={"Content-Type": "application/json"}, bearer_token="token"),
+        dict(url=GET_ENDPOINT, headers={"Content-Type": "application/json"}, token="token"),
+    ],
+)
+def test_get_headers(params):
+    """
+    Authorization headers are being converted into SecretStr under the hood to avoid dumping any
+    sensitive content into logs. However, when calling the `get_headers` method, the SecretStr is being
+    converted back to string, otherwise sensitive info would have looked like '**********'.
+    """
+    # Arrange and Act
+    step = HttpStep(**params).get_headers()
 
+    # Assert
+    actual_headers = step.get_headers()
     assert actual_headers["Authorization"] != "**********"
     assert actual_headers["Authorization"] == "Bearer token"
     assert actual_headers["Content-Type"] == "application/json"


### PR DESCRIPTION
Adds support for including a bearer token in the HTTP module headers along with proper masking to ensure the token's 'secret' status is maintained.

## Changes
- Added default ability to include a bearer token in the headers.
- Implemented masking for the bearer token in any output to maintain its 'secret' status.
- Updated the get_headers method in the Http module to accommodate these changes.
- Added unit tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #157 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current implementation of get_headers did not support adding a bearer token by default and did not properly mask the token in the output. This posed a security risk. This PR addresses these issues by adding default support for bearer tokens and ensuring that they are masked in any output.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests were added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
