### PR TITLE
[BUGFIX] Fix Context initialization with another Context object

### DIFF
--- a/src/koheesio/context.py
+++ b/src/koheesio/context.py
@@ -85,7 +85,7 @@ class Context(Mapping):
             if isinstance(arg, dict):
                 kwargs.update(arg)
             if isinstance(arg, Context):
-                kwargs = kwargs.update(arg.to_dict())
+                kwargs.update(arg.to_dict())
 
         if kwargs:
             for key, value in kwargs.items():

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -168,6 +168,18 @@ def test_contains():
             # recursive
             True,
         ),
+        (
+            # Test Context initialization with another Context object
+            # ---
+            # left_context
+            Context({"foo": "bar"}),
+            # right_context
+            Context(Context({"baz": "qux"})),
+            # expected
+            {"foo": "bar", "baz": "qux"},
+            # recursive
+            None,
+        ),
     ],
 )
 def test_merge(left_context, right_context, expected, recursive):
@@ -211,6 +223,16 @@ def test_from_dict():
                 "b": True,
                 "c": [{"d": 2, "e": "nested"}, 1, "test2", False, {"f": 2, "g": [{"d": 2, "e": "nested"}, 1, "test3"]}],
             },
+        ),
+        (
+            # Test Context initialization with another Context object
+            Context(Context({"baz": "qux"})),
+            {"baz": "qux"},
+        ),
+        (
+            # Test with just kwargs
+            Context(foo="bar", baz="qux"),
+            {"foo": "bar", "baz": "qux"},
         ),
     ],
 )


### PR DESCRIPTION
## Description
The __init__ method of the Context class incorrectly updated the `kwargs` making it return `None`. This means that calls to Context containing another Context object, would previously fail.

## Related Issue
Closes #159 

## How Has This Been Tested?
Several unit tests were added to cover the intended behavior - this was previously not covered

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
