### PR TITLE
[BUGFIX] Fix log duplication when using specific super call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,7 @@ name.".*(pyspark35r).*".env-vars = [
 
 
 [tool.pytest.ini_options]
-addopts = "-q --color=yes --order-scope=module"
+addopts = "-vv --color=yes --order-scope=module"
 log_level = "CRITICAL"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "scope"
@@ -428,6 +428,14 @@ features = [
   "test",
   "docs",
 ]
+extra-dependencies = [
+  "pyspark[connect]==3.5.4",
+]
+
+# Enable this if you want Spark Connect in your dev environment
+[tool.hatch.envs.dev.env-vars]
+SPARK_REMOTE = "local"
+SPARK_TESTING = "True"
 
 
 ###  ~~~~~~~~~~~~~~~~~~  ###

--- a/src/koheesio/spark/readers/hana.py
+++ b/src/koheesio/spark/readers/hana.py
@@ -61,7 +61,8 @@ class HanaReader(JdbcReader):
         default="com.sap.db.jdbc.Driver",
         description="Make sure that the necessary JARs are available in the cluster: ngdbc-2-x.x.x.x",
     )
-    options: Optional[Dict[str, Any]] = Field(
+    params: Optional[Dict[str, Any]] = Field(
         default={"fetchsize": 2000, "numPartitions": 10},
         description="Extra options to pass to the SAP HANA JDBC driver",
+        alias="options",
     )

--- a/src/koheesio/spark/readers/jdbc.py
+++ b/src/koheesio/spark/readers/jdbc.py
@@ -9,11 +9,12 @@ JdbcReader
 
 from typing import Any, Dict, Optional
 
-from koheesio.models import Field, SecretStr
+from koheesio import ExtraParamsMixin
+from koheesio.models import Field, SecretStr, model_validator
 from koheesio.spark.readers import Reader
 
 
-class JdbcReader(Reader):
+class JdbcReader(Reader, ExtraParamsMixin):
     """
     Reader for JDBC tables.
 
@@ -49,10 +50,16 @@ class JdbcReader(Reader):
         user="YOUR_USERNAME",
         password="***",
         dbtable="schema_name.table_name",
-        options={"fetchsize": 100},
+        options={"fetchsize": 100},  # you can also use 'params' instead of 'options'
     )
     df = jdbc_mssql.read()
     ```
+
+    ### ExtraParamsMixin
+
+    The `ExtraParamsMixin` is a mixin class that provides a way to pass extra parameters to the reader. The extra
+    parameters are stored in the `params` (or `options`) attribute. Any key-value pairs passed to the reader will be
+    stored in the `params` attribute.
     """
 
     format: str = Field(default="jdbc", description="The type of format to load. Defaults to 'jdbc'.")
@@ -71,7 +78,7 @@ class JdbcReader(Reader):
         default=None, description="Database table name, also include schema name", alias="table"
     )
     query: Optional[str] = Field(default=None, description="Query")
-    options: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Extra options to pass to spark reader")
+    params: Dict[str, Any] = Field(default_factory=dict, description="Extra options to pass to spark reader", alias="options")
 
     def get_options(self) -> Dict[str, Any]:
         """
@@ -79,33 +86,46 @@ class JdbcReader(Reader):
 
         Note: override this method if driver requires custom names, e.g. Snowflake: `sfUrl`, `sfUser`, etc.
         """
-        return {
+        _options = {
             "driver": self.driver,
             "url": self.url,
             "user": self.user,
             "password": self.password,
-            **self.options,  # type: ignore
+            **self.params,
         }
+        if query := self.query:
+            _options["query"] = query
 
-    def execute(self) -> Reader.Output:
-        """Wrapper around Spark's jdbc read format"""
+        # Check that only one of them is filled in
+        if query and self.dbtable:
+            self.log.warning("Query is filled in, dbtable will be ignored!")
+        else:
+            _options["dbtable"] = self.dbtable
 
-        # Can't have both dbtable and query empty
+        return _options
+
+    @model_validator(mode="after")
+    def check_dbtable_or_query(self) -> "JdbcReader":
+        """Check that dbtable or query is filled in and that only one of them is filled in (query has precedence)"""
+        # Check that dbtable or query is filled in
         if not self.dbtable and not self.query:
             raise ValueError("Please do not leave dbtable and query both empty!")
 
-        if self.query and self.dbtable:
-            self.log.info("Both 'query' and 'dbtable' are filled in, 'dbtable' will be ignored!")
+        return self
 
+    @property
+    def options(self) -> Dict[str, Any]:
+        """Shorthand for accessing self.params provided for backwards compatibility"""
+        return self.params
+
+    def execute(self) -> "JdbcReader.Output":
+        """Wrapper around Spark's jdbc read format"""
         options = self.get_options()
 
         if pw := self.password:
             options["password"] = pw.get_secret_value()
 
         if query := self.query:
-            options["query"] = query
-            self.log.info(f"Executing query: {self.query}")
-        else:
-            options["dbtable"] = self.dbtable
+            self.log.info(f"Executing query: {query}")
 
         self.output.df = self.spark.read.format(self.format).options(**options).load()

--- a/src/koheesio/spark/readers/teradata.py
+++ b/src/koheesio/spark/readers/teradata.py
@@ -67,6 +67,7 @@ class TeradataReader(JdbcReader):
         "com.teradata.jdbc.TeraDriver",
         description="Make sure that the necessary JARs are available in the cluster: terajdbc4-x.x.x.x",
     )
-    options: Optional[Dict[str, Any]] = Field(
-        {"fetchsize": 2000, "numPartitions": 10}, description="Extra options to pass to the Teradata JDBC driver"
+    params: Optional[Dict[str, Any]] = Field(
+        {"fetchsize": 2000, "numPartitions": 10}, description="Extra options to pass to the Teradata JDBC driver",
+        alias="options",
     )

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -197,9 +197,10 @@ class StepMetaClass(ModelMetaclass):
             True if the method is called through super(), False otherwise.
 
         """
-
-        base_class = caller_self.__class__.__bases__[0]
-        return caller_name in base_class.__dict__
+        for base_class in caller_self.__class__.__mro__:
+            if caller_name in base_class.__dict__:
+                return True
+        return False
 
     @classmethod
     def _partialmethod_impl(mcs, cls: type, execute_method: Callable) -> partialmethod:
@@ -274,7 +275,16 @@ class StepMetaClass(ModelMetaclass):
         """
 
         # check if the method is called through super() in the immediate parent class
-        caller_name = inspect.currentframe().f_back.f_back.f_code.co_name
+        # Find the closest 'execute' method after '_execute_wrapper'
+        caller_name = None
+        found_execute_wrapper = False
+        for frame in inspect.stack():
+            if frame.function == "_execute_wrapper":
+                found_execute_wrapper = True
+            elif found_execute_wrapper and frame.function == "execute":
+                caller_name = frame.function
+                break
+
         is_called_through_super_ = cls._is_called_through_super(step, caller_name)
 
         cls._log_start_message(step=step, skip_logging=is_called_through_super_)

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -274,9 +274,14 @@ class StepMetaClass(ModelMetaclass):
 
         """
 
-        # check if the method is called through super() in the immediate parent class
-        caller_name = inspect.currentframe().f_back.f_back.f_code.co_name
-
+        # Check if the method is called through super() in the immediate parent class
+        caller_name = (
+            inspect.currentframe()  # Current stack frame
+            .f_back  # Previous stack frame (caller of the current function)
+            .f_back  # Parent stack frame (caller of the caller function)
+            .f_code  # Code object of that frame
+            .co_name  # Name of the function from the code object
+        )
         is_called_through_super_ = cls._is_called_through_super(step, caller_name)
 
         cls._log_start_message(step=step, skip_logging=is_called_through_super_)

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -275,15 +275,7 @@ class StepMetaClass(ModelMetaclass):
         """
 
         # check if the method is called through super() in the immediate parent class
-        # Find the closest 'execute' method after '_execute_wrapper'
-        caller_name = None
-        found_execute_wrapper = False
-        for frame in inspect.stack():
-            if frame.function == "_execute_wrapper":
-                found_execute_wrapper = True
-            elif found_execute_wrapper and frame.function == "execute":
-                caller_name = frame.function
-                break
+        caller_name = inspect.currentframe().f_back.f_back.f_code.co_name
 
         is_called_through_super_ = cls._is_called_through_super(step, caller_name)
 

--- a/src/koheesio/steps/__init__.py
+++ b/src/koheesio/steps/__init__.py
@@ -178,7 +178,7 @@ class StepMetaClass(ModelMetaclass):
     @staticmethod
     def _is_called_through_super(caller_self: Any, caller_name: str, *_args, **_kwargs) -> bool:  # type: ignore[no-untyped-def]
         """
-        Check if the method is called through super() in the immediate parent class.
+        Check if the method is called through super() using MRO (Method Resolution Order).
 
         Parameters
         ----------

--- a/tests/spark/readers/test_jdbc.py
+++ b/tests/spark/readers/test_jdbc.py
@@ -45,7 +45,7 @@ class TestJdbcReader:
         }
         del expected["password"]  # we don't need to test for this
 
-        assert actual == expected
+        assert sorted(actual) == sorted(expected)
 
     def test_execute_wo_dbtable_and_query(self):
         with pytest.raises(ValueError) as e:

--- a/tests/spark/readers/test_jdbc.py
+++ b/tests/spark/readers/test_jdbc.py
@@ -14,11 +14,11 @@ class TestJdbcReader:
     }
 
     def test_get_options_wo_extra_options(self):
-        jr = JdbcReader(**self.common_options)
+        jr = JdbcReader(**self.common_options, dbtable="table")
         actual = jr.get_options()
         del actual["password"]  # we don't need to test for this
 
-        expected = {**self.common_options}
+        expected = {**self.common_options, "dbtable": "table"}
         del expected["password"]  # we don't need to test for this
 
         assert actual == expected
@@ -29,6 +29,8 @@ class TestJdbcReader:
                 "foo": "foo",
                 "bar": "bar",
             },
+            query = "unit test",
+            dbtable = "table",
             **self.common_options,
         )
 
@@ -37,6 +39,7 @@ class TestJdbcReader:
 
         expected = {
             **self.common_options,
+            "query": "unit test",
             "foo": "foo",
             "bar": "bar",
         }
@@ -45,9 +48,8 @@ class TestJdbcReader:
         assert actual == expected
 
     def test_execute_wo_dbtable_and_query(self):
-        jr = JdbcReader(**self.common_options)
         with pytest.raises(ValueError) as e:
-            jr.execute()
+            _ = JdbcReader(**self.common_options)
             assert e.type is ValueError
 
     def test_execute_w_dbtable_and_query(self, dummy_spark):

--- a/tests/spark/transformations/test_hash.py
+++ b/tests/spark/transformations/test_hash.py
@@ -13,8 +13,7 @@ log = LoggingFactory.get_logger(name="test_hash")
 @pytest.mark.parametrize(
     "input_values,input_data,expected",
     [
-        (
-            # description: base test
+        pytest.param(
             # input values,
             dict(target_column="hash", column="id"),
             None,
@@ -24,9 +23,9 @@ log = LoggingFactory.get_logger(name="test_hash")
                 dict(id=2, string="world", hash="d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"),
                 dict(id=3, string="", hash="4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"),
             ],
+            id="base test",
         ),
-        (
-            # description: multiple column input
+        pytest.param(
             # input values,
             dict(target_column="hash", columns=["id", "string"]),
             None,
@@ -36,9 +35,9 @@ log = LoggingFactory.get_logger(name="test_hash")
                 dict(id=2, string="world", hash="939ac689cbc0affd630000575a8edb83583130ca570ab6000124c25f985603cf"),
                 dict(id=3, string="", hash="626938c3fd46f4155cc77ec411626ef8188af25ad6829f2ad4c068ebc5d92fbf"),
             ],
+            id="multiple column input",
         ),
-        (
-            # description: null column input
+        pytest.param(
             # input values,
             dict(target_column="hash", column="string"),
             ([["hello"], ["world"], [None]], ["string"]),
@@ -48,9 +47,9 @@ log = LoggingFactory.get_logger(name="test_hash")
                 dict(string="world", hash="486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"),
                 dict(string=None, hash=None),
             ],
+            id="null column input",
         ),
-        (
-            # description: null column input along with other columns
+        pytest.param(
             # input values,
             dict(target_column="hash", columns=["id", "string"]),
             ([[1, "hello"], [2, "world"], [3, None]], ["id", "string"]),
@@ -60,6 +59,7 @@ log = LoggingFactory.get_logger(name="test_hash")
                 dict(id=2, string="world", hash="939ac689cbc0affd630000575a8edb83583130ca570ab6000124c25f985603cf"),
                 dict(id=3, string=None, hash="4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce"),
             ],
+            id="null column input along with other columns",
         ),
     ],
 )
@@ -92,24 +92,15 @@ def test_with_same_data_as_from_spark_docs(spark):
 @pytest.mark.parametrize(
     "input_values,error",
     [
-        (
-            # description: non-existent column
+        pytest.param(
             # input values,
             dict(target_column="hash", columns="column_does_not_exist"),
             # expected error
-            Exception,
+            ValueError,
+            id="non-existent column",
         ),
     ],
 )
 def test_unhappy_flow(input_values, error, sample_df_with_strings):
-    log.info(
-        dedent(
-            f"""
-            input values: {input_values}
-            expected error: {error}
-            """
-        )
-    )
-
     with pytest.raises(error):
         Sha2Hash(**input_values).transform(sample_df_with_strings)

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -80,7 +80,7 @@ STATUS_503_ENDPOINT = f"{BASE_URL}/status/503"
         ),
     ],
 )
-def test_http_step(endpoint, step, method, return_value, expected_status_code):
+def test_http_step(endpoint: str, step: HttpStep, method: str, return_value: dict, expected_status_code: int) -> None:
     """
     Unit Testing the GET functions.
     Above parameters are for the success and failed GET API calls
@@ -95,11 +95,13 @@ def test_http_step(endpoint, step, method, return_value, expected_status_code):
                 "Content-Type": "application/json",
             },
         )
+        # Unhappy path
         if expected_status_code not in (200, 202, 204):
             with pytest.raises(HTTPError) as excinfo:
                 step.execute()
 
             assert excinfo.value.response.status_code == expected_status_code
+        # Happy path
         else:
             step.execute()
             assert step.output.status_code == expected_status_code  # type: ignore

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -114,14 +114,14 @@ def test_http_step_with_valid_http_method():
     Above parameters are for the success and failed GET API calls
     """
 
-    with Mocker() as rm:
+    with requests_mock.Mocker() as rm:
         rm.get(GET_ENDPOINT, status_code=int(200))
         response = HttpStep(method="get", url=GET_ENDPOINT).execute()
         assert response.status_code == 200
 
 
 def test_http_step_with_invalid_http_method():
-    with Mocker() as rm:
+    with requests_mock.Mocker() as rm:
         rm.get(GET_ENDPOINT, status_code=int(200))
         # Will be raised during class instantiation
         with pytest.raises(AttributeError):
@@ -129,7 +129,7 @@ def test_http_step_with_invalid_http_method():
 
 
 def test_http_step_request():
-    with Mocker() as rm:
+    with requests_mock.Mocker() as rm:
         rm.put(PUT_ENDPOINT, status_code=int(200))
         # The default method for HttpStep class is GET, however the method specified in `request` options is PUT and
         # it will override the default

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -3,7 +3,7 @@ import requests
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RetryError
-from requests_mock.mocker import Mocker
+import requests_mock
 from urllib3 import Retry
 
 from koheesio.steps.http import (
@@ -86,7 +86,7 @@ def test_http_step(endpoint: str, step: HttpStep, method: str, return_value: dic
     Above parameters are for the success and failed GET API calls
     """
 
-    with Mocker() as rm:
+    with requests_mock.Mocker() as rm:
         rm.request(method=method, url=endpoint, json=return_value, status_code=int(expected_status_code))
         step = step(
             url=endpoint,


### PR DESCRIPTION
This PR addresses the issue of duplicate logs when using a `super()` call in the execute method of a Step class under the specific condition where `super()` was not pointing to the direct ancestor of the called `Step`. The problem was caused by the `_is_called_through_super` method of the `StepMetaClass` not being able to inspect beyond the immediate ancestor of the called object. 

This fix involves updating the `_is_called_through_super` method to traverse the entire method resolution order (MRO) and correctly identify if the `execute`-method is called through `super()` in any parent class of its direct ancestry. 

Additionally, the `_execute_wrapper` method was updated to ensure logging is only triggered once per execute call.

## Related Issue
Closes #167 

## Motivation and Context
This change is required to prevent duplicate logs when using `super()` in nested Step classes. The updated logic ensures that the logging mechanism correctly identifies and handles `super()` calls, providing accurate and non-redundant log entries. The `_is_called_through_super` method was not just used for logs, but also for `Output` validation - although I did not witness any direct issues with this, this fix ensure that we call this only once also.

## How Has This Been Tested?

Additional unit tests were added to reproduce the issue as observed prior 

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
