### PR TITLE
[BUGFIX] OktaAccessToken bug and enhance logging and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
 #        hatch fmt --check --python=${{ matrix.python-version }}
 
     - name: Run tests
-      run: hatch test --python=${{ matrix.python-version }} -i version=pyspark${{ matrix.pyspark-version }} --verbose
+      run: hatch test --python=${{ matrix.python-version }} -i version=pyspark${{ matrix.pyspark-version }} --verbose --randomize
 
   # https://github.com/marketplace/actions/alls-green#why
   final_check: # This job does nothing and is only used for the branch protection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
 #        hatch fmt --check --python=${{ matrix.python-version }}
 
     - name: Run tests
-      run: hatch test --python=${{ matrix.python-version }} -i version=pyspark${{ matrix.pyspark-version }} --verbose --randomize
+      run: hatch test --python=${{ matrix.python-version }} -i version=pyspark${{ matrix.pyspark-version }} --verbose
 
   # https://github.com/marketplace/actions/alls-green#why
   final_check: # This job does nothing and is only used for the branch protection

--- a/docs/releases/0.10.md
+++ b/docs/releases/0.10.md
@@ -25,18 +25,18 @@ For users currently using v0.9, consider the following:
 
 ## Release 0.10.1
 
-**v0.10.1** - *2025-03-05*
+**v0.10.1** - *2025-03-11*
 
 * **Full Changelog**:
     https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.0...koheesio-v0.10.1
 
-!!! abstract "refactor - PR [#...](https://github.com/Nike-Inc/koheesio/pull/...)"
+!!! abstract "refactor - PR [#174](https://github.com/Nike-Inc/koheesio/pull/174)"
     #### *Core*: Clarify experimental nature of `SecretStr.__format__`
 
     <small> by @dannymeijer </small>  
 
-!!! bug "bugfix - PR [#...](https://github.com/Nike-Inc/koheesio/pull/...)"
-    #### *...*: Bug in `OktaAccessToken`
+!!! bug "bugfix - PR [#174](https://github.com/Nike-Inc/koheesio/pull/174)"
+    #### *SSO > Okta*: Bug in `OktaAccessToken`
 
     Changes to HttpStep class caused `OktaAccessToken` to fail:
     

--- a/docs/releases/0.10.md
+++ b/docs/releases/0.10.md
@@ -23,9 +23,33 @@ For users currently using v0.9, consider the following:
 
 * `JDBCReader`, `HanaReader`, and `TeradataReader` classes have been updated to use `params` over `options` for improved consistency and maintainability. The `options` field has been renamed to `params`, and an alias `options` has been added for backwards compatibility. These changes provide a more consistent API across different reader classes and improve code readability. Note that `dbtable` and `query` validation now occurs upon *initialization* rather than at *runtime*, requiring either `dbtable` or `query` to be submitted to use JDBC based classes.
 
+## Release 0.10.1
+
+**v0.10.1** - *2025-03-05*
+
+* **Full Changelog**:
+    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.0...koheesio-v0.10.1
+
+!!! abstract "refactor - PR [#...](https://github.com/Nike-Inc/koheesio/pull/...)"
+    #### *Core*: Clarify experimental nature of `SecretStr.__format__`
+
+    <small> by @dannymeijer </small>  
+
+!!! bug "bugfix - PR [#...](https://github.com/Nike-Inc/koheesio/pull/...)"
+    #### *...*: Bug in `OktaAccessToken`
+
+    Changes to HttpStep class caused `OktaAccessToken` to fail:
+    
+    * Fixed by switching `OktaAccessToken` to use `get_options` instead of a `model_validator`
+    * Added several tests to ensure this doesn't happen again
+    
+    Additionally, fixed issue that might cause `client_secret` to be exposed in logs
+    
+    <small> by @dannymeijer</small>
+
 ## Release 0.10.0
 
-**v0.10.0** - *2025-03-..*
+**v0.10.0** - *2025-03-04*
 
 * **Full Changelog**:  
     https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.9.1...koheesio-v0.10.0

--- a/src/koheesio/__about__.py
+++ b/src/koheesio/__about__.py
@@ -12,7 +12,7 @@ enhancing productivity and code maintainability.
 
 LICENSE_INFO = "Licensed as Apache 2.0"
 SOURCE = "https://github.com/Nike-Inc/koheesio"
-__version__ = "0.10.1a0"
+__version__ = "0.10.1"
 __logo__ = (
     75,
     (

--- a/src/koheesio/__about__.py
+++ b/src/koheesio/__about__.py
@@ -12,7 +12,7 @@ enhancing productivity and code maintainability.
 
 LICENSE_INFO = "Licensed as Apache 2.0"
 SOURCE = "https://github.com/Nike-Inc/koheesio"
-__version__ = "0.10.0"
+__version__ = "0.10.1a0"
 __logo__ = (
     75,
     (

--- a/src/koheesio/logger.py
+++ b/src/koheesio/logger.py
@@ -90,7 +90,10 @@ class Masked(Generic[T]):
             line
             for f in inspect.stack()
             for line in (f.code_context or [])
-            if any(e in line.strip() for e in [".debug(", ".info(", ".log(", ".warning(", "print("])
+            if any(
+                e in line.strip()
+                for e in [".debug(", ".info(", ".log(", ".warning(", ".error(", ".critical(", "print("]
+            )
         ]
         return repr(self._value if not used_as_output else "*" * len(str(self._value)) + "(Masked)")
 

--- a/src/koheesio/models/__init__.py
+++ b/src/koheesio/models/__init__.py
@@ -51,7 +51,6 @@ from pydantic._internal._model_construction import ModelMetaclass
 
 from koheesio.context import Context
 from koheesio.logger import Logger, LoggingFactory
-from koheesio.utils import experimental
 
 __all__ = [
     "BaseModel",

--- a/src/koheesio/models/__init__.py
+++ b/src/koheesio/models/__init__.py
@@ -50,6 +50,7 @@ from pydantic._internal._model_construction import ModelMetaclass
 
 from koheesio.context import Context
 from koheesio.logger import Logger, LoggingFactory
+from koheesio.utils import experimental
 
 __all__ = [
     "BaseModel",
@@ -875,6 +876,7 @@ class SecretStr(PydanticSecretStr, _SecretMixin):
         Returns the actual secret value.
     """
 
+    @experimental
     def __format__(self, format_spec: str) -> str:
         """Advanced f-string formatting support.
         If the f-string is called from within a SecretStr, the secret value is returned as we are in a secure context.

--- a/src/koheesio/models/__init__.py
+++ b/src/koheesio/models/__init__.py
@@ -18,6 +18,7 @@ import inspect
 from pathlib import Path
 import re
 import sys
+import warnings
 
 # to ensure that koheesio.models is a drop in replacement for pydantic
 from pydantic import BaseModel as PydanticBaseModel
@@ -876,12 +877,24 @@ class SecretStr(PydanticSecretStr, _SecretMixin):
         Returns the actual secret value.
     """
 
-    @experimental
     def __format__(self, format_spec: str) -> str:
         """Advanced f-string formatting support.
         If the f-string is called from within a SecretStr, the secret value is returned as we are in a secure context.
         Otherwise, we consider the context 'unsafe' and we let pydantic take care of the formatting.
+
+        !!! warning "Experimental Feature"\n'
+            This method is experimental and may change or be removed in future versions if deemed unstable. 
+            Use with caution!
         """
+
+        warnings.warn(
+            "`SecretStr.__format__`: "
+            "This method is experimental and may change or be removed in future versions if deemed unstable. "
+            "Use with caution!",
+            category=UserWarning,
+            stacklevel=2,
+        )
+
         # Inspect the call stack to determine if the string is being passed through SecretStr
         stack = inspect.stack(context=1)
         caller_context = stack[1].code_context[0]  # type: ignore

--- a/src/koheesio/sso/okta.py
+++ b/src/koheesio/sso/okta.py
@@ -21,7 +21,7 @@ class Okta(HttpPostStep):
 
     client_id: str = Field(default=..., alias="okta_id", description="Okta account ID")
     client_secret: SecretStr = Field(default=..., alias="okta_secret", description="Okta account secret", repr=False)
-    data: Optional[Union[Dict[str, str], str]] = Field(
+    data: Dict[str, str] = Field(
         default={"grant_type": "client_credentials"}, description="Data to be sent along with the token request"
     )
 

--- a/src/koheesio/sso/okta.py
+++ b/src/koheesio/sso/okta.py
@@ -4,13 +4,13 @@ This module contains Okta integration steps.
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 from logging import Filter, LogRecord
 
 from requests import HTTPError
 
 from koheesio.logger import LoggingFactory, MaskedString
-from koheesio.models import Field, SecretStr, model_validator
+from koheesio.models import Field, SecretStr
 from koheesio.steps.http import HttpPostStep
 
 
@@ -25,15 +25,14 @@ class Okta(HttpPostStep):
         default={"grant_type": "client_credentials"}, description="Data to be sent along with the token request"
     )
 
-    @model_validator(mode="before")
-    def _set_auth_param(cls, v: dict) -> dict:
-        """
-        Assign auth parameter with Okta client and secret to the params dictionary.
-        If auth parameter already exists, it will be overwritten.
-        """
-        auth = (v["client_id"], MaskedString(v["client_secret"].get_secret_value()))
-        v["params"] = {"auth": auth} if not v.get("params") else {**v["params"], "auth": auth}
-        return v
+    # headers are not used in this class
+    headers: dict = {}
+
+    def get_options(self) -> dict:
+        """options to be passed to requests.request()"""
+        _options = super().get_options()
+        _options["auth"] = (self.client_id, MaskedString(self.client_secret.get_secret_value()))
+        return _options
 
 
 class LoggerOktaTokenFilter(Filter):
@@ -56,7 +55,8 @@ class OktaAccessToken(Okta):
     """
     Get Okta authorization token
 
-    Example:
+    Examples
+    --------
     ```python
     token = (
         OktaAccessToken(
@@ -89,7 +89,7 @@ class OktaAccessToken(Okta):
         """
         Execute an HTTP Post call to Okta service and retrieve the access token.
         """
-        HttpPostStep.execute(self)
+        super().execute()
 
         # noinspection PyUnresolvedReferences
         status_code = self.output.status_code

--- a/src/koheesio/utils/__init__.py
+++ b/src/koheesio/utils/__init__.py
@@ -113,25 +113,3 @@ def utc_now() -> datetime.datetime:
     if PYTHON_MINOR_VERSION < 3.11:
         return datetime.datetime.utcnow()
     return datetime.datetime.now(datetime.timezone.utc)
-
-
-def experimental(func: Callable) -> Callable:
-    """Decorator to mark functions as experimental."""
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Callable:
-        warnings.warn(
-            f"{func.__name__} is experimental and might be removed in a future minor release if deemed unstable.",
-            category=UserWarning,
-            stacklevel=2,
-        )
-        return func(*args, **kwargs)
-    
-    # Add experimental warning to the docstring
-    original_doc = func.__doc__ or ""
-    func.__doc__ = original_doc + (
-        '\n'
-        '!!! warning "Experimental Feature"\n'
-        '    This method is experimental and may change in future versions if deemed unstable. Use with caution!'
-    )
-
-    return wrapper

--- a/src/koheesio/utils/__init__.py
+++ b/src/koheesio/utils/__init__.py
@@ -4,12 +4,13 @@ Utility functions
 
 from typing import Any, Callable, Dict, Optional, Tuple
 import datetime
-from functools import partial
+from functools import partial, wraps
 from importlib import import_module
 import inspect
 from pathlib import Path
 from sys import version_info as PYTHON_VERSION
 import uuid
+import warnings
 
 __all__ = [
     "get_args_for_func",
@@ -112,3 +113,25 @@ def utc_now() -> datetime.datetime:
     if PYTHON_MINOR_VERSION < 3.11:
         return datetime.datetime.utcnow()
     return datetime.datetime.now(datetime.timezone.utc)
+
+
+def experimental(func: Callable) -> Callable:
+    """Decorator to mark functions as experimental."""
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Callable:
+        warnings.warn(
+            f"{func.__name__} is experimental and might be removed in a future minor release if deemed unstable.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+        return func(*args, **kwargs)
+    
+    # Add experimental warning to the docstring
+    original_doc = func.__doc__ or ""
+    func.__doc__ = original_doc + (
+        '\n'
+        '!!! warning "Experimental Feature"\n'
+        '    This method is experimental and may change in future versions if deemed unstable. Use with caution!'
+    )
+
+    return wrapper


### PR DESCRIPTION
* Addressed a bug in the OktaAccessToken class related to headers setup by ensurin they remain blank.
* Also fixed an issue with secret masking in OktaAccessToken
* Added experimental to `SecretStr.__format__` method for clarification
* Updated version to 0.10.1 
* and documented changes in release notes.
 
Several tests were added to cover the newly discovered edge cases and logging issues.