### PR TITLE
Fixed checking merge builder type in DeltaTableWriter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,19 +39,18 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
-    - name: Fetch target branch
-      run: git fetch origin ${{ github.event.pull_request.head.ref || 'main'}}:${{ github.event.pull_request.base.ref || 'main'}}
+
     - name: Check changes
       id: check
       run: |
-          # Set the base reference for the git diff
-          BASE_REF=${{ github.event.pull_request.base.ref || 'main' }}
-        
-          # Check for changes in this PR / commit
-          git_diff_output=$(git diff --name-only $BASE_REF ${{ github.event.after }})
-        
+          # Fetch the base branch
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+
+          # Get the diff between PR base and head
+          git_diff_output=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+
           # Count the number of changes to Python and TOML files
           python_changed=$(echo "$git_diff_output" | grep '\.py$' | wc -l)
           toml_changed=$(echo "$git_diff_output" | grep '\.toml$' | wc -l)

--- a/src/koheesio/spark/writers/delta/batch.py
+++ b/src/koheesio/spark/writers/delta/batch.py
@@ -328,11 +328,11 @@ class DeltaTableWriter(Writer, ExtraParamsMixin):
                     clause = merge_conf.get("clause")
                     if clause not in valid_clauses:
                         raise ValueError(f"Invalid merge clause '{clause}' provided")
-            elif (
-                not isinstance(merge_builder, DeltaMergeBuilder)
-                or not type(merge_builder).__name__ == "DeltaMergeBuilder"
+            elif not (
+                isinstance(merge_builder, DeltaMergeBuilder)
+                or type(merge_builder).__name__ == "DeltaMergeBuilder"
             ):
-                raise ValueError("merge_builder must be a list or merge clauses or a DeltaMergeBuilder instance")
+                raise ValueError("merge_builder must be a list of merge clauses or a DeltaMergeBuilder instance")
 
         return params
 


### PR DESCRIPTION
## Description
There was a small error in validating merge builder type when using the `merge_builder` param with `DeltaTableWriter`. It required that the value passed was either a `list` or a `delta.tables.DeltaMergeBuilder` instance so validation failed when an instance of `delta.connect.tables.DeltaMergeBuilder` was passed.

## Motivation and Context
One cannot pass a correct DeltaMergeBuilder instance as a merge builder for `DeltaTableWriter` if it's not a `delta.tables.DeltaMergeBuilder` instance or a `list`. Connect merge builders should also be supported.

## How Has This Been Tested?
4 dedicated test cases have been added to test the merge builder validation.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
