### PR TITLE
Ensure matched inserts sync to snowflake

### DIFF
--- a/src/koheesio/integrations/spark/snowflake.py
+++ b/src/koheesio/integrations/spark/snowflake.py
@@ -970,7 +970,7 @@ class SynchronizeDeltaToSnowflakeTask(SnowflakeSparkStep):
             f"""
             MERGE INTO {target_table} target
             USING {stage_table} temp ON {key_join_string}
-            WHEN MATCHED AND temp._change_type = 'update_postimage'
+            WHEN MATCHED AND (temp._change_type = 'update_postimage' OR temp._change_type = 'insert')
                 THEN UPDATE SET {assignment_string}
             WHEN NOT MATCHED AND temp._change_type != 'delete'
                 THEN INSERT ({columns_string})

--- a/tests/spark/integrations/snowflake/test_sync_task.py
+++ b/tests/spark/integrations/snowflake/test_sync_task.py
@@ -495,7 +495,7 @@ class TestMergeQuery:
             """
             MERGE INTO target_table target
             USING tmp_table temp ON target.Country = temp.Country
-            WHEN MATCHED AND temp._change_type = 'update_postimage'
+            WHEN MATCHED AND (temp._change_type = 'update_postimage' OR temp._change_type = 'insert')
                 THEN UPDATE SET NumVaccinated = temp.NumVaccinated, AvailableDoses = temp.AvailableDoses
             WHEN NOT MATCHED AND temp._change_type != 'delete'
                 THEN INSERT (Country, NumVaccinated, AvailableDoses)

--- a/tests/spark/integrations/snowflake/test_sync_task.py
+++ b/tests/spark/integrations/snowflake/test_sync_task.py
@@ -474,7 +474,7 @@ class TestMergeQuery:
             """
             MERGE INTO target_table target
             USING tmp_table temp ON target.Country = temp.Country
-            WHEN MATCHED AND temp._change_type = 'update_postimage'
+            WHEN MATCHED AND (temp._change_type = 'update_postimage' OR temp._change_type = 'insert')
                 THEN UPDATE SET NumVaccinated = temp.NumVaccinated, AvailableDoses = temp.AvailableDoses
             WHEN NOT MATCHED AND temp._change_type != 'delete'
                 THEN INSERT (Country, NumVaccinated, AvailableDoses)


### PR DESCRIPTION
Ensure a new INSERT is synchronized to Snowflake, even when a match is already found.

## Description
When a delta table is VACUUMed before a sync to Snowflake was triggered, a updated record will be considered as an "INSERT" record. However the target table might already contain this record. This PR ensures that this record is still updated as would be desired.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
When a delta table is VACUUMed before a sync to Snowflake was triggered, a updated record will be considered as an "INSERT" record. However the target table might already contain this record. This PR ensures that this record is still updated as would be desired.

## How Has This Been Tested?
This was a bug in our code. This code currently lives in our repo and fixed the issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
