### PR TITLE
Peek transformation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ test = [
   "pytest-randomly",
   "pytest-sftpserver",
   "pytest-xdist",
+  "flaky",
   "requests_mock",
   "time_machine",
   "freezegun",

--- a/src/koheesio/spark/transformations/debug.py
+++ b/src/koheesio/spark/transformations/debug.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from koheesio.spark import SparkStep
+from koheesio.spark.transformations import Transformation
+
+from koheesio.models import Field
+
+
+class Peek(Transformation):
+    """ Peek the DataFrame. Easily enable / disable peeking with the is_active parameter. """
+    is_active: bool = Field(..., description="Enables / disables this transformation to easily switch from peeking during a development phase to skipping this step in a production environment")
+    print_schema: Optional[bool] = Field(default=False, description="Enables printing the schema of the DataFrame")
+    truncate_output: Optional[bool] = Field(default=False, description="Whether to truncate the output when printing the DataFrame")
+    vertical: Optional[bool] = Field(default=False, description="Whether to print the DataFrame vertically")
+    n: Optional[int] = Field(default=20, description="Number of rows to show")
+
+    def execute(self) -> SparkStep.Output:
+        if self.is_active:
+            self._peek()
+        return self.output
+
+    def _peek(self):
+        if self.print_schema:
+            self.df.printSchema()
+
+        self.df.show(truncate=self.truncate_output, n=self.n, vertical=self.vertical)

--- a/src/koheesio/spark/transformations/debug.py
+++ b/src/koheesio/spark/transformations/debug.py
@@ -1,26 +1,118 @@
-from typing import Optional
+"""
+In this module you will find utility transformations that are useful for debugging and development purposes.
+"""
 
+from typing import Optional
+from logging import DEBUG
+
+from koheesio.models import Field
 from koheesio.spark import SparkStep
 from koheesio.spark.transformations import Transformation
 
-from koheesio.models import Field
-
 
 class Peek(Transformation):
-    """ Peek the DataFrame. Easily enable / disable peeking with the is_active parameter. """
-    is_active: bool = Field(..., description="Enables / disables this transformation to easily switch from peeking during a development phase to skipping this step in a production environment")
+    """
+    Peek the DataFrame: lets you inspect the content and/or the schema of the DataFrame at any given point of a Koheesio
+    pipeline.
+
+    You may want to run or disable this step depending on the environment the pipeline is running in. This can be
+    accomplished by configuring the `enabled` and `enabled_by_logger` flags. The idea is that you can simply have the
+    `enabled` flag decide whether to run the transformation (in this case, `enabled_by_logger` must be set to False),
+    or you can run it based on the current log level. To accomplish that, set both `enabled` and `enabled_by_logger`
+    to True: the step will be executed only if the log level is set to DEBUG.
+
+    Here's a table that summarizes the scenarios and the expected behavior of the step:
+
+    +----------------+---------------------+---------------------+---------------------+
+    | enabled        | enabled_by_logger   | log level           | Is Peek enabled?    |
+    +----------------+---------------------+---------------------+---------------------+
+    | False          | *                   | *                   | NO                  |
+    | True           | False               | *                   | YES                 |
+    | True           | True                | DEBUG               | YES                 |
+    | True           | True                | INFO or higher      | NO                  |
+    +----------------+---------------------+---------------------+---------------------+
+
+    You can simply slide in this transformation in between the transformations you wish to apply in order to peek the
+    DataFrame data and schema:
+
+    Example
+    -------
+    ```python
+    from koheesio.spark.etl_task import EtlTask
+    from koheesio.spark.readers.dummy import DummyReader
+    from koheesio.spark.transformations.debug import Peek
+    from koheesio.spark.transformations.transform import Transform
+    from koheesio.spark.writers.dummy import DummyWriter
+
+    reader = DummyReader(n=10)
+    writer = DummyWriter()
+    transformations = [
+        Peek(enabled=True, enabled_by_logger=False, print_schema=True),
+        Transform(
+            lambda df: df.withColumn("id_squared", df["id"] * df["id"])
+        ),
+        Peek(enabled=True, enabled_by_logger=False, print_schema=True),
+    ]
+    task = EtlTask(
+        source=reader, transformations=transformations, target=writer
+    )
+    task.execute()
+    ```
+    """
+
+    enabled: bool = Field(
+        ...,
+        description="Whether to run this step or not. The resulting behavior may influenced by "
+        "the enabled_by_logger paramter and the current log level. See the class "
+        "docstring for more details.",
+    )
+
+    enabled_by_logger: Optional[bool] = Field(
+        default=False,
+        description="Enables the step if the log level of the logger is set to DEBUG or lower. The resulting behavior "
+        "may influenced by the enabled parameter and the current log level. See the class docstring for "
+        "more details.",
+    )
+
     print_schema: Optional[bool] = Field(default=False, description="Enables printing the schema of the DataFrame")
-    truncate_output: Optional[bool] = Field(default=False, description="Whether to truncate the output when printing the DataFrame")
-    vertical: Optional[bool] = Field(default=False, description="Whether to print the DataFrame vertically")
+    truncate_output: Optional[bool] = Field(
+        default=False, description="Whether to truncate the output when printing the DataFrame"
+    )
+    vertical: Optional[bool] = Field(default=False, description="Print the DataFrame vertically")
     n: Optional[int] = Field(default=20, description="Number of rows to show")
 
     def execute(self) -> SparkStep.Output:
-        if self.is_active:
+        if self.active:
             self._peek()
-        return self.output
 
     def _peek(self):
+        self.df = self.df.cache()
+
         if self.print_schema:
             self.df.printSchema()
 
         self.df.show(truncate=self.truncate_output, n=self.n, vertical=self.vertical)
+        self.output.df = self.df
+
+    @property
+    def active(self) -> bool:
+        # The is active parameter takes precedence over the logger level
+        if not self.enabled:
+            return False
+
+        # Is active is True, and enabled by logger is False, we don't care about current log level
+        if not self.enabled_by_logger:
+            return True
+
+        # If both flags are True, it will be active based on log level
+        if self._on_debug():
+            return True
+
+        return False
+
+    def _on_debug(self) -> bool:
+        """
+        Check if the logger level is set to DEBUG or lower.
+        :return: True if the logger level is set to DEBUG or lower, False otherwise.
+        """
+        return self.log.isEnabledFor(DEBUG)

--- a/src/koheesio/spark/transformations/debug.py
+++ b/src/koheesio/spark/transformations/debug.py
@@ -113,6 +113,10 @@ class Peek(Transformation):
     def _on_debug(self) -> bool:
         """
         Check if the logger level is set to DEBUG or lower.
-        :return: True if the logger level is set to DEBUG or lower, False otherwise.
+
+        Returns
+        --------
+        bool
+            True if the logger level is set to DEBUG or lower, False otherwise.
         """
         return self.log.isEnabledFor(DEBUG)

--- a/tests/spark/transformations/test_debug.py
+++ b/tests/spark/transformations/test_debug.py
@@ -1,32 +1,73 @@
-from koheesio.spark.transformations.debug import Peek
+import logging
+
 import pytest
+
+from koheesio.logger import LoggingFactory
+from koheesio.spark.transformations.debug import Peek
 
 
 @pytest.mark.parametrize(
-    "input_values,expected_calls",
+    "log_level,expected",
     [
+        ("DEBUG", True),
+        ("INFO", False),
+        ("WARNING", False),
+    ],
+)
+def test_on_debug(monkeypatch, log_level, expected):
+    LoggingFactory(level=log_level)
+
+    peek = Peek(enabled=True)
+    actual = peek._on_debug()
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "input_values,log_level,expected_calls",
+    [
+        # description: enabled is False, irrespective of log level or enabled by logger, it should not run
         (
-            # description: Peek is active, print schema, truncate output, vertical display
-            dict(is_active=True, print_schema=True, truncate_output=True, vertical=True, n=10),
+            dict(enabled=False, enabled_by_logger=True, truncate_output=True, vertical=True, n=10, print_schema=True),
+            "INFO",
+            dict(printSchema=0, show=0),
+        ),
+        (
+            dict(enabled=False, enabled_by_logger=True, truncate_output=True, vertical=True, n=10),
+            "DEBUG",
+            dict(printSchema=0, show=0),
+        ),
+        # description: enabled is True and enabled_by_logger is False, it should run irrespective of log level
+        (
+            dict(enabled=True, enabled_by_logger=False, truncate_output=True, vertical=True, n=10, print_schema=True),
+            "WARNING",
             dict(printSchema=1, show=1),
         ),
         (
-            # description: Peek is active, do not print schema, do not truncate output, horizontal display
-            dict(is_active=True, print_schema=False, truncate_output=False, vertical=False, n=5),
+            dict(enabled=True, enabled_by_logger=False, truncate_output=True, vertical=True, n=10, print_schema=False),
+            "DEBUG",
             dict(printSchema=0, show=1),
         ),
+        # description: both Flags True, it should run based on log level (DEBUG or lower)
         (
-            # description: Peek is inactive
-            dict(is_active=False, print_schema=True, truncate_output=True, vertical=True, n=10),
+            dict(enabled=True, enabled_by_logger=True, truncate_output=True, vertical=True, n=10, print_schema=False),
+            "INFO",
             dict(printSchema=0, show=0),
+        ),
+        (
+            dict(enabled=True, enabled_by_logger=True, truncate_output=True, vertical=True, n=10, print_schema=True),
+            "DEBUG",
+            dict(printSchema=1, show=1),
         ),
     ],
 )
-def test_peek(spark, mocker, input_values, expected_calls):
+def test_peek(spark, mocker, monkeypatch, input_values, log_level, expected_calls):
     input_df = spark.createDataFrame(
         [("Banana lemon orange", 1000, "USA"), ("Carrots Blueberries", 1500, "USA"), ("Beans", 1600, "USA")],
         schema="product string, amount int, country string",
     )
+
+    # Set the expected log level
+    LoggingFactory(level=log_level)
 
     peek = Peek(**input_values)
     peek.df = input_df
@@ -42,4 +83,6 @@ def test_peek(spark, mocker, input_values, expected_calls):
     assert peek.df.show.call_count == expected_calls["show"]
 
     if expected_calls["show"] > 0:
-        peek.df.show.assert_called_with(truncate=input_values["truncate_output"], n=input_values["n"], vertical=input_values["vertical"])
+        peek.df.show.assert_called_with(
+            truncate=input_values["truncate_output"], n=input_values["n"], vertical=input_values["vertical"]
+        )

--- a/tests/spark/transformations/test_debug.py
+++ b/tests/spark/transformations/test_debug.py
@@ -1,0 +1,45 @@
+from koheesio.spark.transformations.debug import Peek
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_values,expected_calls",
+    [
+        (
+            # description: Peek is active, print schema, truncate output, vertical display
+            dict(is_active=True, print_schema=True, truncate_output=True, vertical=True, n=10),
+            dict(printSchema=1, show=1),
+        ),
+        (
+            # description: Peek is active, do not print schema, do not truncate output, horizontal display
+            dict(is_active=True, print_schema=False, truncate_output=False, vertical=False, n=5),
+            dict(printSchema=0, show=1),
+        ),
+        (
+            # description: Peek is inactive
+            dict(is_active=False, print_schema=True, truncate_output=True, vertical=True, n=10),
+            dict(printSchema=0, show=0),
+        ),
+    ],
+)
+def test_peek(spark, mocker, input_values, expected_calls):
+    input_df = spark.createDataFrame(
+        [("Banana lemon orange", 1000, "USA"), ("Carrots Blueberries", 1500, "USA"), ("Beans", 1600, "USA")],
+        schema="product string, amount int, country string",
+    )
+
+    peek = Peek(**input_values)
+    peek.df = input_df
+
+    # Mock the methods
+    peek.df.printSchema = mocker.MagicMock()
+    peek.df.show = mocker.MagicMock()
+
+    peek.execute()
+
+    # Check if the methods were called the expected number of times
+    assert peek.df.printSchema.call_count == expected_calls["printSchema"]
+    assert peek.df.show.call_count == expected_calls["show"]
+
+    if expected_calls["show"] > 0:
+        peek.df.show.assert_called_with(truncate=input_values["truncate_output"], n=input_values["n"], vertical=input_values["vertical"])

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -207,6 +207,7 @@ def test_get_headers(params: dict, expected: str, caplog: pytest.LogCaptureFixtu
         pytest.param(17, STATUS_404_ENDPOINT, 503, 1, HTTPError, id="max_retries_17_404"),
     ],
 )
+@pytest.mark.flaky(max_runs=3)  # We seldom experience 502 errors on httbin, so we try again
 def test_max_retries(
     max_retries: int, endpoint: str, status_code: int, expected_count: int, error_type: Exception
 ) -> None:
@@ -235,6 +236,7 @@ def test_max_retries(
         pytest.param(1, [0, 2, 4], id="backoff_1"),
     ],
 )
+@pytest.mark.flaky(max_runs=3)  # We seldom experience 502 errors on httbin, so we try again
 def test_initial_delay_and_backoff(monkeypatch: pytest.FixtureRequest, backoff: int, expected: list) -> None:
     session = requests.Session()
     retry_logic = Retry(total=3, backoff_factor=backoff, status_forcelist=[503])

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -207,7 +207,7 @@ def test_get_headers(params: dict, expected: str, caplog: pytest.LogCaptureFixtu
         pytest.param(17, STATUS_404_ENDPOINT, 503, 1, HTTPError, id="max_retries_17_404"),
     ],
 )
-@pytest.mark.flaky(max_runs=3)  # We seldom experience 502 errors on httbin, so we try again
+@pytest.mark.flaky(max_runs=3)  # We occasionally experience 502 errors on httbin, so we try again
 def test_max_retries(
     max_retries: int, endpoint: str, status_code: int, expected_count: int, error_type: Exception
 ) -> None:
@@ -236,7 +236,7 @@ def test_max_retries(
         pytest.param(1, [0, 2, 4], id="backoff_1"),
     ],
 )
-@pytest.mark.flaky(max_runs=3)  # We seldom experience 502 errors on httbin, so we try again
+@pytest.mark.flaky(max_runs=3)  # We occasionally experience 502 errors on httbin, so we try again
 def test_initial_delay_and_backoff(monkeypatch: pytest.FixtureRequest, backoff: int, expected: list) -> None:
     session = requests.Session()
     retry_logic = Retry(total=3, backoff_factor=backoff, status_forcelist=[503])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a Peek transformation that can be used during development and debugging of tasks.

## Motivation and Context
It can be handy to inspect the schema / peek the content of the data during the development / debugging, more so if the data pipeline involves multiple transformation. The peek transformation can be inserted in the most critical sections to easily inspect the content or schema, and can be easily enabled / disabled using a flag so that it does not need to be removed from the pipeline when that is moved to a production environment.

## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
