### PR TITLE
bugfix - prevent table parameter duplication in Snowflake options dictionary

### DIFF
--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -1,0 +1,23 @@
+# Koheesio 0.11
+
+Version 0.11 is Koheesio's 5th release since getting Open Sourced.
+
+This version brings several important improvements and bug fixes across different modules of Koheesio. The overall API remains unchanged.
+
+## Release 0.11.0
+
+**v0.11.0** - *2025-04-17*
+
+* **Full Changelog**:
+    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.2...koheesio-v0.11.0
+
+### Bugfixes
+
+The following bugfixes are included with 0.11:
+
+!!! bug "bugfix - PR [#190](https://github.com/Nike-Inc/koheesio/pull/190), related issue #188"
+    #### *Snowflake*: Fixed table parameter duplication in options dictionary
+
+    Fixed an issue in `SnowflakeBaseModel.get_options()` where the 'table' parameter was being included in the options dictionary, causing conflicts in nested operations like `AddColumn` during schema synchronization. The fix excludes the table parameter while maintaining proper parameter handling for Snowflake connections, ensuring that operations can properly cascade options without parameter conflicts. The implementation also improves overall parameter handling across the Snowflake and JDBC reader classes while maintaining backwards compatibility.
+
+    <small> by @dannymeijer</small>

--- a/src/koheesio/integrations/snowflake/__init__.py
+++ b/src/koheesio/integrations/snowflake/__init__.py
@@ -201,8 +201,12 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         examples=["example.snowflakecomputing.com"],
     )
     user: str = Field(default=..., alias="sfUser", description="Login name for the Snowflake user")
-    password: Optional[SecretStr] = Field(default=None, alias="sfPassword", description="Password for the Snowflake user")
-    private_key: Optional[SecretStr] = Field(default=None, alias="pem_private_key", description="PEM private key for the Snowflake user")
+    password: Optional[SecretStr] = Field(
+        default=None, alias="sfPassword", description="Password for the Snowflake user"
+    )
+    private_key: Optional[SecretStr] = Field(
+        default=None, alias="pem_private_key", description="PEM private key for the Snowflake user"
+    )
     role: str = Field(
         default=..., alias="sfRole", description="The default security role to use for the session after connecting"
     )
@@ -236,9 +240,7 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         if not self.password and not self.private_key:
             raise ValueError("You must provide either 'password' or 'private_key'.")
         if self.password and self.private_key:
-            raise ValueError(
-                "You must provide either 'password' or 'private_key', not both."
-            )
+            raise ValueError("You must provide either 'password' or 'private_key', not both.")
         return self
 
     @property
@@ -273,24 +275,25 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         """
         # Always exclude these fields unless explicitly included
         base_exclude = {
-            "name", "description",  # Koheesio specific
-            "params", "options",    # Handled separately
-            "sfSchema",            # Handled separately
-            "password",            # Handled separately
-            "private_key",         # Handled separately
-            "table",              # Prevent conflicts - this is our key fix!
+            # Koheesio specific
+            "name",
+            "description",
+            # Handled separately
+            "params",
+            "options",
+            "sfSchema",
+            "password",
+            "private_key",
+            # Prevent conflicts
+            "table",
         }
         exclude_set = base_exclude - (include or set())
 
         # Get base fields from model, excluding None values and specified fields
-        fields = self.model_dump(
-            by_alias=by_alias,
-            exclude_none=True,
-            exclude=exclude_set
-        )
+        fields = self.model_dump(by_alias=by_alias, exclude_none=True, exclude=exclude_set)
 
         # Add schema - always present for Snowflake
-        fields.update({ "sfSchema" if by_alias else "schema": self.sfSchema })
+        fields.update({"sfSchema" if by_alias else "schema": self.sfSchema})
 
         # Handle authentication - password or private_key
         if self.password:
@@ -414,7 +417,6 @@ class SnowflakeRunQueryPython(SnowflakeStep):
             raise RuntimeError("Snowflake connector is not installed. Please install `snowflake-connector-python`.")
 
         sf_options = self.get_options()
-
 
         _conn = self._snowflake_connector.connect(**sf_options)
         self.log.info(f"Connected to Snowflake account: {sf_options['account']}")

--- a/src/koheesio/integrations/spark/snowflake.py
+++ b/src/koheesio/integrations/spark/snowflake.py
@@ -640,12 +640,10 @@ class SnowflakeWriter(SnowflakeBaseModel, Writer):
     def execute(self) -> SnowflakeWriter.Output:
         """Write to Snowflake"""
         self.log.debug(f"writing to {self.table} with mode {self.insert_type}")
-        
+
         options = self.get_options()
-        
-        self.df.write.format(self.format).options(**options).option("dbtable", self.table).mode(
-            self.insert_type
-        ).save()
+
+        self.df.write.format(self.format).options(**options).option("dbtable", self.table).mode(self.insert_type).save()
 
 
 class SynchronizeDeltaToSnowflakeTask(SnowflakeSparkStep):

--- a/src/koheesio/spark/readers/jdbc.py
+++ b/src/koheesio/spark/readers/jdbc.py
@@ -76,7 +76,9 @@ class JdbcReader(Reader, ExtraParamsMixin):
     )
     user: str = Field(default=..., description="User to authenticate to the server")
     password: Optional[SecretStr] = Field(default=None, description="Password belonging to the username")
-    private_key: Optional[SecretStr] = Field(default=None, alias="pem_private_key", description="Private key for authentication")
+    private_key: Optional[SecretStr] = Field(
+        default=None, alias="pem_private_key", description="Private key for authentication"
+    )
     dbtable: Optional[str] = Field(
         default=None,
         description="Database table name, also include schema name",
@@ -95,12 +97,7 @@ class JdbcReader(Reader, ExtraParamsMixin):
         Note: override this method if driver requires custom names, e.g. Snowflake: `sfUrl`, `sfUser`, etc.
         """
         # Build base connection parameters
-        options = {
-            "driver": self.driver,
-            "url": self.url,
-            "user": self.user,
-            "password": self.password
-        }
+        options = {"driver": self.driver, "url": self.url, "user": self.user, "password": self.password}
 
         # Add extra params from params/options
         if self.params:
@@ -131,9 +128,7 @@ class JdbcReader(Reader, ExtraParamsMixin):
         if not self.password and not self.private_key:
             raise ValueError("You must provide either 'password' or 'private_key'.")
         if self.password and self.private_key:
-            raise ValueError(
-                "You must provide either 'password' or 'private_key', not both."
-            )
+            raise ValueError("You must provide either 'password' or 'private_key', not both.")
 
         return self
 
@@ -145,7 +140,7 @@ class JdbcReader(Reader, ExtraParamsMixin):
     def execute(self) -> "JdbcReader.Output":
         """Wrapper around Spark's jdbc read format"""
         options = self.get_options()
-        
+
         # Update password with secret value
         if pw := self.password:
             options["password"] = pw.get_secret_value()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -327,8 +327,7 @@ def test_from_yaml_path_object_nonexistent_file():
     except AttributeError as e:
         # If it raises AttributeError, it should NOT be about 'read'
         assert "'read'" not in str(e), (
-            f"Bug #226: from_yaml() should not raise AttributeError about 'read' when passed a Path object. "
-            f"Got: {e}"
+            f"Bug #226: from_yaml() should not raise AttributeError about 'read' when passed a Path object. Got: {e}"
         )
 
 

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -261,10 +261,10 @@ class TestSnowflakeBaseModel:
             role="role",
             warehouse="warehouse",
             schema="schema",
-            table="test_table"  # This should be excluded
+            table="test_table",  # This should be excluded
         )
         options = k.get_options()
-        
+
         # table parameter should not be present in options
         assert "table" not in options
         assert "sfTable" not in options  # Also check aliased form

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -251,6 +251,29 @@ class TestSnowflakeBaseModel:
         assert "warehouse" not in options
         assert "schema" not in options
 
+    def test_table_parameter_excluded(self):
+        """Test that the table parameter is excluded from get_options output to prevent duplicate parameters"""
+        k = SnowflakeBaseModel(
+            url="hostname.com",
+            user="user",
+            password="password",
+            database="database",
+            role="role",
+            warehouse="warehouse",
+            schema="schema",
+            table="test_table"  # This should be excluded
+        )
+        options = k.get_options()
+        
+        # table parameter should not be present in options
+        assert "table" not in options
+        assert "sfTable" not in options  # Also check aliased form
+
+        # but other parameters should still be present
+        assert options["sfURL"] == "hostname.com"
+        assert options["sfUser"] == "user"
+        assert options["sfDatabase"] == "database"
+
 
 class TestSnowflakeStep:
     def test_initialization(self):

--- a/tests/spark/integrations/snowflake/test_sync_task.py
+++ b/tests/spark/integrations/snowflake/test_sync_task.py
@@ -58,23 +58,6 @@ def foreach_batch_stream_local(checkpoint_folder, snowflake_staging_file):
     )
 
 
-@pytest.fixture(scope="session")
-def merge_test_table(spark):
-    """Create test table once per session instead of for each test"""
-    table = DeltaTableStep(database="klettern", table="test_merge")
-    spark.sql(
-        dedent(
-            f"""
-            CREATE OR REPLACE TABLE {table.table_name}
-            (Country STRING, NumVaccinated LONG, AvailableDoses LONG)
-            USING DELTA
-            TBLPROPERTIES ('delta.enableChangeDataFeed' = true);
-            """
-        )
-    )
-    return table
-
-
 class TestSnowflakeSyncTask:
     @mock.patch.object(SynchronizeDeltaToSnowflakeTask, "writer")
     def test_overwrite(self, mock_writer, spark):
@@ -142,80 +125,77 @@ class TestSnowflakeSyncTask:
         task.execute()
         chispa.assert_df_equality(task.output.target_df, df)
 
-    def test_merge(self, spark, foreach_batch_stream_local, snowflake_staging_file, mocker, merge_test_table):
-        """Test merging data from Delta to Snowflake"""
-        # Patch SnowflakeRunQueryPython.execute
+    def test_merge(self, spark, foreach_batch_stream_local, snowflake_staging_file, mocker):
+        # Arrange - Prepare Delta requirements
         mocker.patch("koheesio.integrations.spark.snowflake.SnowflakeRunQueryPython.execute")
-        
-        # Create task with cached table
+        source_table = DeltaTableStep(database="klettern", table="test_merge")
+        spark.sql(
+            dedent(
+                f"""
+                CREATE OR REPLACE TABLE {source_table.table_name}
+                (Country STRING, NumVaccinated LONG, AvailableDoses LONG)
+                USING DELTA
+                TBLPROPERTIES ('delta.enableChangeDataFeed' = true);
+                """
+            )
+        )
+
+        # Arrange - Prepare local representation of snowflake
         task = SynchronizeDeltaToSnowflakeTask(
             streaming=True,
             synchronisation_mode=BatchOutputMode.MERGE,
-            **{**COMMON_OPTIONS, "source_table": merge_test_table, "account": "sf_account"},
+            **{**COMMON_OPTIONS, "source_table": source_table, "account": "sf_account"},
         )
 
-        # Add initial data using batch insert
-        initial_data = [
-            ("Australia", 100, 3000),
-            ("USA", 10000, 20000),
-            ("UK", 7000, 10000)
-        ]
-        spark.createDataFrame(initial_data, ["Country", "NumVaccinated", "AvailableDoses"]) \
-            .write.format("delta").mode("append").saveAsTable(merge_test_table.table_name)
+        # Arrange - Add data to previously empty Delta table
+        spark.sql(
+            dedent(
+                f"""
+                INSERT INTO {source_table.table_name} VALUES
+                ("Australia", 100, 3000),
+                ("USA", 10000, 20000),
+                ("UK", 7000, 10000);
+                """
+            )
+        )
 
-        # Run initial sync
+        # Act - Run code
+        # Note: We are using the foreach_batch_stream_local fixture to simulate writing to a live environment
         mocker.patch.object(SynchronizeDeltaToSnowflakeTask, "writer", new=foreach_batch_stream_local)
         task.execute()
         task.writer.await_termination()
 
-        # Validate initial sync
-        results_df = spark.read.parquet(snowflake_staging_file).select("Country", "NumVaccinated", "AvailableDoses")
-        source_df = spark.sql(f"SELECT * FROM {merge_test_table.table_name}")
-        
+        # Assert - Validate result
+        df = spark.read.parquet(snowflake_staging_file).select("Country", "NumVaccinated", "AvailableDoses")
         chispa.assert_df_equality(
-            results_df,
-            source_df,
+            df,
+            spark.sql(f"SELECT * FROM {source_table.table_name}"),
             ignore_row_order=True,
             ignore_column_order=True,
         )
-        assert results_df.count() == 3
+        assert df.count() == 3
 
-        # Perform updates in a single batch
-        update_data = [("BELGIUM", 10, 100)]
-        spark.createDataFrame(update_data, ["Country", "NumVaccinated", "AvailableDoses"]) \
-            .write.format("delta").mode("append").saveAsTable(merge_test_table.table_name)
-        
-        spark.sql(f"""
-            UPDATE {merge_test_table.table_name} 
-            SET NumVaccinated = 20 
-            WHERE Country = 'BELGIUM'
-        """)
+        # Perform update
+        spark.sql(f"""INSERT INTO {source_table.table_name} VALUES ("BELGIUM", 10, 100)""")
+        spark.sql(f"UPDATE {source_table.table_name} SET NumVaccinated = 20 WHERE Country = 'Belgium'")
 
-        # Run sync after updates
+        # Run code
         with mock.patch.object(SynchronizeDeltaToSnowflakeTask, "writer", new=foreach_batch_stream_local):
-            task.execute()
-            # More specific await that checks for completion of specific operations
-            await_job_completion(spark, timeout=60)  # Reduced timeout since we're being more efficient
+            # Test that this call doesn't raise exception after all queries were completed
             task.writer.await_termination()
+            task.execute()
+            await_job_completion(spark)
 
-        # Cache the final read operations
-        results_df = spark.read.parquet(snowflake_staging_file) \
-            .select("Country", "NumVaccinated", "AvailableDoses") \
-            .cache()
-        source_df = spark.sql(f"SELECT * FROM {merge_test_table.table_name}").cache()
+        # Validate result
+        df = spark.read.parquet(snowflake_staging_file).select("Country", "NumVaccinated", "AvailableDoses")
 
-        # Validate final state
         chispa.assert_df_equality(
-            results_df,
-            source_df,
+            df,
+            spark.sql(f"SELECT * FROM {source_table.table_name}"),
             ignore_row_order=True,
             ignore_column_order=True,
         )
-        assert results_df.count() == 4
-
-        # Unpersist cached DataFrames
-        results_df.unpersist()
-        source_df.unpersist()
+        assert df.count() == 4
 
     def test_writer(self, spark):
         source_table = DeltaTableStep(datbase="klettern", table="test_overwrite")


### PR DESCRIPTION
Fixed an issue in `SnowflakeBaseModel.get_options()` where the 'table' parameter was being included in the options dictionary, causing conflicts in nested operations - like `AddColumn` - during schema synchronization. The fix excludes the table parameter while maintaining proper parameter handling for Snowflake connections, ensuring that operations can properly cascade options without parameter conflicts. 

The implementation also improves overall parameter handling across the Snowflake and JDBC reader classes while maintaining backwards compatibility.

## Related Issue
closes #188 

## How Has This Been Tested?
New test has been added to cover for this scenario

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
