### PR TITLE
bugfix - snowflakereader complains either dbtable or query must be passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,6 @@ out/**
 *.iml
 
 /tests/integration/**/task_definition/*.yaml
-/.vscode/settings.json
 /.vscode/launch.json
 
 .databricks

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "python.testing.pytestArgs": [
+        ".",
+        "-n 3",                     // Run tests in parallel with 2 workers
+        "--durations=10",           // Show the 10 slowest tests
+        "-vv",                      // Verbose output
+        "--cache-clear",            // Clear cache before running to prevent stale cache issues
+        "--random-order",           // Randomize test execution order
+        "--random-order-bucket=global", // Randomization scope. Possible values: global, module, or class
+        "--random-order-seed=time", // Use 'time' as seed for reproducibility
+        "--maxfail=3",              // Stop after 3 failures
+        "--last-failed",            // Run previously failed tests first
+        "--tb=short",               // Shorter tracebacks
+        "--showlocals",             // Show local variables in tracebacks
+        "--strict-markers"          // Ensure markers are registered
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "python.testing.pytestArgs": [
         ".",
-        "-n 3",                     // Run tests in parallel with 2 workers
+        "-n 3",                     // Run tests in parallel with 3 workers
         "--durations=10",           // Show the 10 slowest tests
         "-vv",                      // Verbose output
         "--cache-clear",            // Clear cache before running to prevent stale cache issues

--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -1,0 +1,51 @@
+# Koheesio 0.11
+
+Version 0.11 is Koheesio's 5th release since getting Open Sourced.
+
+This version brings several important architectural improvements and bug fixes across different modules of Koheesio. 
+The overall API remains unchanged, but internal implementations have been enhanced for better reliability and maintainability.
+
+## Release 0.11.0
+
+**v0.11.0** - *2025-04-17*
+
+* **Full Changelog**:
+    [View on GitHub](https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.2...koheesio-v0.11.0)
+
+### Improvements
+
+!!! note "improvement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191), related issue #175"
+    #### Enhanced JDBC and Snowflake Integration Architecture
+    
+    Introduced a new abstract `BaseJdbcReader` class that improves how JDBC and Snowflake connections handle their parameters:
+    - Proper separation of concerns between base JDBC functionality and specific implementations
+    - Enhanced parameter precedence handling (query vs dbtable)
+    - Improved type hints and error handling
+    - Better test coverage with descriptive assertions
+
+    <small>by @dannymeijer</small>
+
+### Testing Infrastructure
+
+!!! note "improvement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191)"
+    #### Enhanced Test Configuration and Reliability
+    
+    Improved test infrastructure with:
+    - Migration from `pytest-randomly` to `pytest-random-order` for better test randomization
+    - Parallel test execution with 3 workers
+    - Persistent VS Code test configuration
+    - Enhanced test failure reporting with local variable inspection
+    
+    <small>by @dannymeijer</small>
+
+### Bugfixes
+
+!!! bug "bugfix - PR [#190](https://github.com/Nike-Inc/koheesio/pull/190), related issue #188"
+    #### Fixed Parameter Handling in Database Connections
+    
+    Fixed an issue where query and table parameters weren't being properly handled in JDBC readers, particularly affecting Snowflake operations. The fix ensures:
+    - Proper precedence between query and dbtable parameters
+    - Correct parameter inheritance in nested database operations
+    - Prevention of duplicate or conflicting parameters in options dictionaries
+
+    <small>by @dannymeijer</small>

--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -12,10 +12,10 @@ The overall API remains unchanged, but internal implementations have been enhanc
 * **Full Changelog**:
     [View on GitHub](https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.2...koheesio-v0.11.0)
 
-### Improvements
+### Features and Enhancements
 
-!!! note "improvement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191), related issue #175"
-    #### Enhanced JDBC and Snowflake Integration Architecture
+!!! abstract "enhancement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191), related issue #175"
+    #### *Snowflake and JDBC*: Enhanced JDBC and Snowflake Integration Architecture
     
     Introduced a new abstract `BaseJdbcReader` class that improves how JDBC and Snowflake connections handle their parameters:
     - Proper separation of concerns between base JDBC functionality and specific implementations
@@ -25,10 +25,8 @@ The overall API remains unchanged, but internal implementations have been enhanc
 
     <small>by @dannymeijer</small>
 
-### Testing Infrastructure
-
-!!! note "improvement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191)"
-    #### Enhanced Test Configuration and Reliability
+!!! abstract "enhancement - PR [#191](https://github.com/Nike-Inc/koheesio/pull/191)"
+    #### *Dev Experience*: Enhanced Test Configuration and Reliability
     
     Improved test infrastructure with:
     - Migration from `pytest-randomly` to `pytest-random-order` for better test randomization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = [
   "pytest-cov",
   "pytest-mock",
   "pytest-order",
-  "pytest-randomly",
+  "pytest-random-order",
   "pytest-sftpserver",
   "pytest-xdist",
   "flaky",

--- a/src/koheesio/integrations/snowflake/__init__.py
+++ b/src/koheesio/integrations/snowflake/__init__.py
@@ -162,6 +162,8 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         https://docs.snowflake.com/en/user-guide/spark-connector-install
     * Refer to Snowflake docs for connection options:
         https://docs.snowflake.com/en/user-guide/spark-connector-use#setting-configuration-options-for-the-connector
+    * Table parameter handling is delegated to the JDBC layer in derived classes like SnowflakeReader.
+      This ensures proper precedence between query and table parameters across all database operations.
 
     Parameters
     ----------

--- a/src/koheesio/integrations/snowflake/__init__.py
+++ b/src/koheesio/integrations/snowflake/__init__.py
@@ -220,7 +220,7 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         default=..., alias="schema", description="The schema to use for the session after connecting"
     )
     params: Optional[Dict[str, Any]] = Field(
-        default_factory=partial(dict, **SF_DEFAULT_PARAMS),
+        default=SF_DEFAULT_PARAMS,  # type: ignore
         description="Extra options to pass to the Snowflake connector, by default it includes "
         "'sfCompress': 'on' and  'continue_on_error': 'off'",
         alias="options",
@@ -385,6 +385,7 @@ class SnowflakeRunQueryPython(SnowflakeStep):
     @property
     @contextmanager
     def conn(self) -> Generator:
+        """Context manager for the Snowflake connection"""
         if not self._snowflake_connector:
             raise RuntimeError("Snowflake connector is not installed. Please install `snowflake-connector-python`.")
 
@@ -392,8 +393,9 @@ class SnowflakeRunQueryPython(SnowflakeStep):
         _conn = self._snowflake_connector.connect(**sf_options)
         self.log.info(f"Connected to Snowflake account: {sf_options['account']}")
 
+        _preserve_snowflake_logger, snowflake_logger = None, None
         try:
-            from snowflake.connector.connection import logger as snowflake_logger
+            from snowflake.connector.connection import logger as snowflake_logger  # type: ignore
 
             _preserve_snowflake_logger = snowflake_logger
             snowflake_logger = self.log

--- a/tests/spark/integrations/snowflake/test_spark_snowflake.py
+++ b/tests/spark/integrations/snowflake/test_spark_snowflake.py
@@ -128,13 +128,13 @@ class TestTableQuery:
 class TestCreateOrReplaceTableFromDataFrame:
     options = {"table": "table", "account": "bar", **COMMON_OPTIONS}
 
-    def test_execute(self, dummy_spark: Mock, dummy_df: Mock, mock_query_local: Mock) -> None:  # pylint: disable=unused-argument
+    def test_execute(self, dummy_spark: Mock, dummy_df: Mock, mock_query: Mock) -> None:  # pylint: disable=unused-argument
         """Test table creation from DataFrame"""
         k = CreateOrReplaceTableFromDataFrame(**self.options, df=dummy_df).execute()  # type: ignore[func-returns-value]
         assert k.snowflake_schema == "id BIGINT"
         assert k.query == "CREATE OR REPLACE TABLE db.schema.table (id BIGINT)"
         assert len(k.input_schema) > 0
-        mock_query_local.assert_called_with(k.query)
+        mock_query.assert_called_with(k.query)
 
 
 class TestGetTableSchema:
@@ -149,11 +149,11 @@ class TestGetTableSchema:
 class TestAddColumn:
     options = {"table": "foo", "column": "bar", "type": t.DateType(), "account": "foo", **COMMON_OPTIONS}
 
-    def test_execute(self, dummy_spark: Mock, mock_query_local: Mock) -> None:  # pylint: disable=unused-argument
+    def test_execute(self, dummy_spark: Mock, mock_query: Mock) -> None:  # pylint: disable=unused-argument
         """Test column addition to table"""
         k = AddColumn(**self.options).execute()  # type: ignore[func-returns-value]
         assert k.query == "ALTER TABLE FOO ADD COLUMN BAR DATE"
-        mock_query_local.assert_called_with(k.query)
+        mock_query.assert_called_with(k.query)
 
 
 class TestSnowflakeWriter:

--- a/tests/spark/integrations/snowflake/test_spark_snowflake.py
+++ b/tests/spark/integrations/snowflake/test_spark_snowflake.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+
 from pyspark.sql import types as t
 
 from koheesio.integrations.snowflake.test_utils import mock_query  # noqa: F401

--- a/tests/spark/integrations/snowflake/test_spark_snowflake.py
+++ b/tests/spark/integrations/snowflake/test_spark_snowflake.py
@@ -45,17 +45,20 @@ def test_snowflake_module_import():
 
 
 class TestSnowflakeReader:
+    """Test the Snowflake reader class"""
     reader_options = {"dbtable": "table", **COMMON_OPTIONS}
 
-    def test_get_options(self):
+    def test_get_options(self) -> None:
+        """Test that options are properly handled"""
         sf = SnowflakeReader(**(self.reader_options | {"authenticator": None}))
         o = sf.get_options()
-        assert sf.format == "snowflake"
-        assert o["sfUser"] == "user"
-        assert o["sfCompress"] == "on"
-        assert "authenticator" not in o
+        assert sf.format == "snowflake", "format should be set to snowflake by default"
+        assert o["sfUser"] == "user", "sfUser should be set by SnowflakeBaseModel"
+        assert o["sfCompress"] == "on", "sfCompress should be set by SnowflakeBaseModel"
+        assert "authenticator" not in o, "authenticator should not be passed to the Snowflake reader"
+        assert o["dbtable"] == "table", "dbtable parameter should be preserved in options"
 
-    def test_execute(self, dummy_spark):
+    def test_execute(self, dummy_spark: Mock) -> None:  # pylint: disable=unused-argument
         """Method should be callable from parent class"""
         k = SnowflakeReader(**self.reader_options).execute()
         assert k.df.count() == 3

--- a/tests/spark/integrations/snowflake/test_spark_snowflake.py
+++ b/tests/spark/integrations/snowflake/test_spark_snowflake.py
@@ -63,6 +63,17 @@ class TestSnowflakeReader:
         k = SnowflakeReader(**self.reader_options).execute()
         assert k.df.count() == 3
 
+    def test_execute_with_dbtable(self, dummy_spark: Mock) -> None:  # pylint: disable=unused-argument
+        """Test that SnowflakeReader works correctly when given a dbtable argument"""
+        reader = SnowflakeReader(**COMMON_OPTIONS, dbtable="my_table")
+        result = reader.execute()  # Save result to avoid unused-variable warning
+
+        options = reader.get_options()
+        assert options["dbtable"] == "my_table", "dbtable should be preserved in options"
+        assert reader.dbtable == "my_table", "dbtable should be preserved on the instance"
+        assert "query" not in options, "query should not be present in options"
+        assert result.df.count() == 3, "DataFrame should be read correctly"
+
 
 class TestRunQuery:
     def test_deprecation(self):

--- a/tests/spark/readers/test_jdbc.py
+++ b/tests/spark/readers/test_jdbc.py
@@ -56,13 +56,15 @@ class TestJdbcReader:
             _ = JdbcReader(**self.common_options)
             assert e.type is ValueError
 
-    def test_execute_w_dbtable_and_query(self, dummy_spark):
+    def test_execute_w_dbtable_and_query(self, dummy_spark) -> None:
         """query should take precedence over dbtable"""
         jr = JdbcReader(**self.common_options, dbtable="foo", query="bar")
         jr.execute()
 
         assert jr.df.count() == 3
+        assert jr.query == "bar"
         assert dummy_spark.options_dict["query"] == "bar"
+        assert jr.dbtable is None
         assert dummy_spark.options_dict.get("dbtable") is None
 
     def test_execute_w_dbtable(self, dummy_spark):

--- a/tests/spark/readers/test_jdbc.py
+++ b/tests/spark/readers/test_jdbc.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from koheesio.spark.readers.jdbc import JdbcReader
@@ -6,6 +8,12 @@ pytestmark = pytest.mark.spark
 
 
 class TestJdbcReader:
+    """Test the JDBC reader functionality and parameter handling
+
+    The tests in this class define the base behavior for all JDBC-based readers,
+    including derived classes like SnowflakeReader.
+    """
+
     common_options = {
         "driver": "driver",
         "url": "url",
@@ -13,7 +21,8 @@ class TestJdbcReader:
         "password": "password",
     }
 
-    def test_get_options_wo_extra_options(self):
+    def test_get_options_wo_extra_options(self) -> None:
+        """Test parameter handling without any extra options"""
         jr = JdbcReader(**self.common_options, dbtable="table")
         actual = jr.get_options()
         del actual["password"]  # we don't need to test for this
@@ -23,7 +32,9 @@ class TestJdbcReader:
 
         assert actual == expected
 
-    def test_get_options_w_extra_options(self):
+    def test_get_options_w_extra_options(self) -> None:
+        """Test parameter handling with extra options present.
+        Validates proper precedence between core and extra parameters."""
         jr = JdbcReader(
             options={
                 "foo": "foo",
@@ -47,17 +58,20 @@ class TestJdbcReader:
 
         assert sorted(actual) == sorted(expected)
         
-        with pytest.raises(KeyError) as e:
-            actual["dbtable"]
-            assert e.type is KeyError
+        # Verify dbtable is not in options
+        assert "dbtable" not in actual.keys()
 
-    def test_execute_wo_dbtable_and_query(self):
+    def test_execute_wo_dbtable_and_query(self) -> None:
+        """Test that error is raised when neither dbtable nor query is provided"""
         with pytest.raises(ValueError) as e:
             _ = JdbcReader(**self.common_options)
             assert e.type is ValueError
 
-    def test_execute_w_dbtable_and_query(self, dummy_spark) -> None:
-        """query should take precedence over dbtable"""
+    def test_execute_w_dbtable_and_query(self, dummy_spark: Mock) -> None:  # pylint: disable=unused-argument
+        """Test that query takes precedence over dbtable.
+        
+        Related to TestSnowflakeReader.test_execute_with_dbtable in test_spark_snowflake.py
+        """
         jr = JdbcReader(**self.common_options, dbtable="foo", query="bar")
         jr.execute()
 
@@ -67,8 +81,8 @@ class TestJdbcReader:
         assert jr.dbtable is None
         assert dummy_spark.options_dict.get("dbtable") is None
 
-    def test_execute_w_dbtable(self, dummy_spark):
-        """check that dbtable is passed to the reader correctly"""
+    def test_execute_w_dbtable(self, dummy_spark: Mock) -> None:  # pylint: disable=unused-argument
+        """Test that dbtable is passed correctly to the reader"""
         jr = JdbcReader(**self.common_options, dbtable="foo")
         jr.execute()
 


### PR DESCRIPTION
This PR introduces significant architectural improvements to the JDBC and Snowflake integration layer, along with enhanced test infrastructure. The key changes are:

### Core Architecture Changes
- Introduced new abstract `BaseJdbcReader` class that encapsulates core JDBC functionality with proper type hints
- Enhanced query/dbtable parameter handling with strict precedence rules
- Improved Snowflake integration by updating `SnowflakeReader` to inherit from `BaseJdbcReader`
- Fixed several type annotations and validator implementations in Snowflake models
- Added comprehensive parameter validation logic in JDBC and Snowflake readers

### Testing & Infrastructure
- Added VS Code test configuration with parallel test execution (3 workers) and test randomization
- Switched from `pytest-randomly` to `pytest-random-order` with global bucket randomization
- Added new test cases for dbtable handling in `SnowflakeReader`
- Improved test assertions with descriptive messages and proper type annotations
- Removed `.vscode/settings.json` from `.gitignore` to persist test configuration

## Related Issue
Closes #175 

## How Has This Been Tested?
New test has been added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
