### PR TITLE
fix: ensure active Spark session retrieval only for supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
 #        os: [ubuntu-latest, windows-latest, macos-latest]  # FIXME: Add Windows and macOS
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12']
         pyspark-version: ['33', '34', '35', '35r']
         exclude:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,27 +281,15 @@ version = ["pyspark35", "pyspark35r"]
 
 [tool.hatch.envs.hatch-test.overrides]
 matrix.version.extra-dependencies = [
-  { value = "pyspark>=3.3,<3.4", if = [
-    "pyspark33",
-  ] },
-  { value = "spark-expectations>=2.1.0", if = [
-    "pyspark33",
-  ] },
-  { value = "pandas<2", if = [
-    "pyspark33",
-  ] },
-  { value = "pyspark>=3.4,<3.5", if = [
-    "pyspark34",
-  ] },
-  { value = "spark-expectations>=2.1.0", if = [
-    "pyspark34",
-  ] },
-  { value = "pyspark>=3.5,<3.6", if = [
-    "pyspark35",
-  ] },
-  { value = "pyspark[connect]>=3.5,<3.6", if = [
-    "pyspark35r",
-  ] },
+  { value = "pyspark>=3.3,<3.4", if = ["pyspark33"] },
+  { value = "spark-expectations>=2.1.0", if = ["pyspark33"] },
+  { value = "pandas<2", if = ["pyspark33"] },
+  { value = "pyspark>=3.4,<3.5", if = ["pyspark34"] },
+  { value = "spark-expectations>=2.1.0", if = ["pyspark34"] },
+  # FIXME: Delta with PySpark 3.5.6 has a bug with overwrite: 
+  # https://github.com/delta-io/delta/issues/4671
+  { value = "pyspark>=3.5,<3.5.6", if = ["pyspark35"] },
+  { value = "pyspark[connect]>=3.5,<3.5.6", if = ["pyspark35r"] },
 ]
 
 name.".*".env-vars = [

--- a/src/koheesio/spark/utils/common.py
+++ b/src/koheesio/spark/utils/common.py
@@ -207,7 +207,7 @@ else:
 
 def get_active_session() -> SparkSession:  # type: ignore
     """Get the active Spark session"""
-    if check_if_pyspark_connect_module_is_available():
+    if check_if_pyspark_connect_module_is_available() and SPARK_MINOR_VERSION >= 3.5:
         from pyspark.sql.connect.session import SparkSession as _ConnectSparkSession
 
         session = _ConnectSparkSession.getActiveSession() or sql.SparkSession.getActiveSession()  # type: ignore

--- a/src/koheesio/spark/writers/buffer.py
+++ b/src/koheesio/spark/writers/buffer.py
@@ -280,8 +280,6 @@ class PandasCsvBufferWriter(BufferWriter, ExtraParamsMixin):
         try:
             import pandas as _pd
 
-            # Get the pandas version as a tuple of integers
-
             pandas_version = version.parse(_pd.__version__)
         except ImportError:
             raise ImportError("Pandas is required to use this writer")

--- a/src/koheesio/spark/writers/buffer.py
+++ b/src/koheesio/spark/writers/buffer.py
@@ -22,6 +22,8 @@ import gzip
 from os import linesep
 from tempfile import SpooledTemporaryFile
 
+from packaging import version
+
 # noinspection PyProtectedMember
 from pandas._typing import CompressionOptions as PandasCompressionOptions
 
@@ -279,12 +281,13 @@ class PandasCsvBufferWriter(BufferWriter, ExtraParamsMixin):
             import pandas as _pd
 
             # Get the pandas version as a tuple of integers
-            pandas_version = tuple(int(i) for i in _pd.__version__.split("."))
+
+            pandas_version = version.parse(_pd.__version__)
         except ImportError:
             raise ImportError("Pandas is required to use this writer")
 
         # Use line_separator for pandas 2.0.0 and later
-        line_sep_option_naming = "line_separator" if pandas_version >= (2, 0, 0) else "line_terminator"
+        line_sep_option_naming = "line_separator" if pandas_version >= version.parse("2.0.0") else "line_terminator"
 
         csv_options = {
             "header": self.header,

--- a/src/koheesio/steps/http.py
+++ b/src/koheesio/steps/http.py
@@ -18,9 +18,9 @@ from typing import Any, Dict, Generator, List, Optional, Union
 import contextlib
 from enum import Enum
 import json
-from urllib3.util import Retry
 
 import requests  # type: ignore[import-untyped]
+from urllib3.util import Retry
 
 from koheesio import Step
 from koheesio.models import (
@@ -293,13 +293,13 @@ class HttpStep(Step, ExtraParamsMixin):
         retries = Retry(
             total=self.max_retries,
             connect=None,  # Only retry on status codes
-            read=None,     # Only retry on status codes
-            redirect=0,    # No redirect retries
+            read=None,  # Only retry on status codes
+            redirect=0,  # No redirect retries
             status=self.max_retries,
             backoff_factor=self.backoff_factor,
             status_forcelist=[502, 503, 504],
-            allowed_methods=frozenset(['GET', 'POST', 'PUT', 'DELETE']),
-            respect_retry_after_header=True
+            allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
+            respect_retry_after_header=True,
         )
         adapter = requests.adapters.HTTPAdapter(max_retries=retries)
         self.session.mount("https://", adapter)

--- a/tests/asyncio/test_asyncio_http.py
+++ b/tests/asyncio/test_asyncio_http.py
@@ -26,8 +26,9 @@ def mock_aiohttp():
 DEFAULT_ASYNC_STEP_PARAMS = {
     "urls": [URL(ASYNC_GET_ENDPOINT), URL(ASYNC_GET_ENDPOINT)],
     "retry_options": ExponentialRetry(),
-    "headers": {"Content-Type": "application/json"}
+    "headers": {"Content-Type": "application/json"},
 }
+
 
 @pytest.mark.asyncio
 def test_async_http_get_step_positive(mock_aiohttp):
@@ -101,9 +102,7 @@ async def test_async_http_step(mock_aiohttp):
     """
     mock_aiohttp.get(ASYNC_GET_ENDPOINT, status=200, repeat=True)
 
-    step = AsyncHttpStep(
-        client_session=ClientSession(), connector=TCPConnector(limit=10), **DEFAULT_ASYNC_STEP_PARAMS
-    )
+    step = AsyncHttpStep(client_session=ClientSession(), connector=TCPConnector(limit=10), **DEFAULT_ASYNC_STEP_PARAMS)
 
     # Execute the step
     responses_urls = await step.get()

--- a/tests/spark/test_spark.py
+++ b/tests/spark/test_spark.py
@@ -51,6 +51,14 @@ class TestSparkStep:
         step = SparkStep()
         assert step.spark is spark
 
+    def test_get_active_session(self):
+        from koheesio.spark.utils.common import get_active_session
+
+        SparkSession.builder.appName("pytest-pyspark-local-testing-active-session").master("local[*]").getOrCreate()
+
+        session = get_active_session()
+        assert session
+
     def test_transformation(self):
         from pyspark.sql import functions as F
 

--- a/tests/steps/test_http.py
+++ b/tests/steps/test_http.py
@@ -88,12 +88,7 @@ log = LoggingFactory.get_logger(name="test_http", inherit_from_koheesio=True)
 )
 def test_http_step(endpoint: str, step: HttpStep, method: str, return_value: dict, expected_status_code: int) -> None:
     """Test basic HTTP methods with success and error responses"""
-    responses.add(
-        getattr(responses, method.upper()),
-        endpoint,
-        json=return_value,
-        status=expected_status_code
-    )
+    responses.add(getattr(responses, method.upper()), endpoint, json=return_value, status=expected_status_code)
 
     step = step(url=endpoint)
 
@@ -200,7 +195,7 @@ def test_get_headers(params: dict, expected: str, caplog: pytest.LogCaptureFixtu
     ],
 )
 def test_max_retries(
-        max_retries: int, endpoint: str, status_code: int, expected_count: int, error_type: Type[Exception]
+    max_retries: int, endpoint: str, status_code: int, expected_count: int, error_type: Type[Exception]
 ) -> None:
     """Test retry behavior for different status codes"""
     request_count = 0
@@ -208,13 +203,9 @@ def test_max_retries(
     def request_callback(request):
         nonlocal request_count
         request_count += 1
-        return (status_code, {}, 'Error')
+        return (status_code, {}, "Error")
 
-    responses.add_callback(
-        responses.GET,
-        endpoint,
-        callback=request_callback
-    )
+    responses.add_callback(responses.GET, endpoint, callback=request_callback)
 
     step = HttpGetStep(url=endpoint, max_retries=max_retries)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve spark logic for getActiveSession

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
