### PR TITLE
Release 0.10.4

### DIFF
--- a/docs/releases/0.10.md
+++ b/docs/releases/0.10.md
@@ -8,9 +8,9 @@ This version brings several important features, security improvements, and bug f
 
 Big shout out to all contributors and a heartfelt welcome to our new contributors:
 
-* @nogitting made their first contribution in https://github.com/Nike-Inc/koheesio/pull/154
-* @zarembat made their first contribution in https://github.com/Nike-Inc/koheesio/pull/163
-* @brunodd made their first contribution in https://github.com/Nike-Inc/koheesio/pull/180
+* @nogitting made their first contribution in <https://github.com/Nike-Inc/koheesio/pull/154>
+* @zarembat made their first contribution in <https://github.com/Nike-Inc/koheesio/pull/163>
+* @brunodd made their first contribution in <https://github.com/Nike-Inc/koheesio/pull/180>
 
 ## Migrating from v0.9
 
@@ -24,12 +24,36 @@ For users currently using v0.9, consider the following:
 
 * `JDBCReader`, `HanaReader`, and `TeradataReader` classes have been updated to use `params` over `options` for improved consistency and maintainability. The `options` field has been renamed to `params`, and an alias `options` has been added for backwards compatibility. These changes provide a more consistent API across different reader classes and improve code readability. Note that `dbtable` and `query` validation now occurs upon *initialization* rather than at *runtime*, requiring either `dbtable` or `query` to be submitted to use JDBC based classes.
 
+## Release 0.10.4
+
+**v0.10.4** - *2025-07-00*
+
+* **Full Changelog**:
+    <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.3...koheesio-v0.10.4>
+
+!!! bug "bugfix - PR [#203](https://github.com/Nike-Inc/koheesio/pull/203), related issue #203"
+    #### *Spark*: ensure correct check of remote modules during retrieval of active Spark session
+
+    Fixed a bug in logic for checking remote modules during retrieval of active Spark session.
+    <small> by @mikita-sakalouski</small>
+
+!!! bug "bugfix - PR [#189](https://github.com/Nike-Inc/koheesio/pull/189), related issue #189"
+    #### *HttpStep*: native retry mechanism
+
+    The original implementation relied on the user providing the custom requests.Session object 
+    with retries and backoff configured. This change embedds the retry mechanism into the class.
+    Also some tests relied on the online service providing various endpoints to test 
+    logic / connectivity / error handling / etc. 
+    The lead to unstable tests. This PR also reworks the tests to leverage mocking for normal 
+    and async HTTP classes and readers.
+    <small> by @maxim-mityutko </small>
+
 ## Release 0.10.3
 
 **v0.10.3** - *2025-05-14*
 
 * **Full Changelog**:
-    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.2...koheesio-v0.10.3
+    <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.2...koheesio-v0.10.3>
 
 !!! bug "bugfix - PR [#194](https://github.com/Nike-Inc/koheesio/pull/194), related issue #175"
     #### *Snowflake*: SnowflakeReader it fails when dbtable is passed in my initialization
@@ -76,7 +100,7 @@ For users currently using v0.9, consider the following:
 **v0.10.2** - *2025-04-02*
 
 * **Full Changelog**:
-    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.1...koheesio-v0.10.2
+    <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.1...koheesio-v0.10.2>
 
 !!! bug "bugfix - PR [#177](https://github.com/Nike-Inc/koheesio/pull/177), related issue #178"
     #### *Tableau*: Hyper process would fail on DBFS
@@ -113,7 +137,7 @@ For users currently using v0.9, consider the following:
 **v0.10.1** - *2025-03-11*
 
 * **Full Changelog**:
-    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.0...koheesio-v0.10.1
+    <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.0...koheesio-v0.10.1>
 
 !!! abstract "refactor - PR [#174](https://github.com/Nike-Inc/koheesio/pull/174)"
     #### *Core*: Clarify experimental nature of `SecretStr.__format__`
@@ -137,7 +161,7 @@ For users currently using v0.9, consider the following:
 **v0.10.0** - *2025-03-04*
 
 * **Full Changelog**:  
-    https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.9.1...koheesio-v0.10.0
+    <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.9.1...koheesio-v0.10.0>
 
 ### Features and Enhancements
 

--- a/src/koheesio/__about__.py
+++ b/src/koheesio/__about__.py
@@ -12,7 +12,7 @@ enhancing productivity and code maintainability.
 
 LICENSE_INFO = "Licensed as Apache 2.0"
 SOURCE = "https://github.com/Nike-Inc/koheesio"
-__version__ = "0.10.4a0"
+__version__ = "0.10.4"
 __logo__ = (
     75,
     (

--- a/src/koheesio/__about__.py
+++ b/src/koheesio/__about__.py
@@ -12,7 +12,7 @@ enhancing productivity and code maintainability.
 
 LICENSE_INFO = "Licensed as Apache 2.0"
 SOURCE = "https://github.com/Nike-Inc/koheesio"
-__version__ = "0.10.3"
+__version__ = "0.10.4a0"
 __logo__ = (
     75,
     (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## What's Changed
* fix: ensure active Spark session retrieval only for supported versions by @mikita-sakalouski in https://github.com/Nike-Inc/koheesio/pull/203
* fix HttpStep: native retry mechanism in https://github.com/Nike-Inc/koheesio/pull/189 by @maxim-mityutko 

**Full Changelog**: https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.3...koheesio-v0.10.4

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
