### PR TITLE
feature - Provide option to cluster table in DeltaTableWriter

### DIFF
--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -1,0 +1,9 @@
+# Koheesio 0.11
+
+This version enhances the functionality of the `DeltaTableWriter` class by providing the ability to cluster delta tables.
+
+
+## Release 0.11.0
+
+The following new features are included in 0.11.0:
+* [FEATURE] - Provide option to cluster table in DeltaTableWriter by @riccamini in https://github.com/Nike-Inc/koheesio/pull/215

--- a/tests/spark/writers/delta/test_delta_writer.py
+++ b/tests/spark/writers/delta/test_delta_writer.py
@@ -537,8 +537,12 @@ def test_delta_table_writer_with_clustering(spark, mocker):
     # Pretending to be on Databricks
     mocker.patch("koheesio.spark.writers.delta.batch.on_databricks", return_value=True)
 
-    # Mocking dataframe writer and methods called in write
-    mock_writer = mocker.patch("pyspark.sql.DataFrame.write")
+    # Mocking write method for the DataFrame class for both PySpark and PySpark Connect
+    if spark.__module__ == 'pyspark.sql.connect.session':
+        mock_writer = mocker.patch("pyspark.sql.connect.dataframe.DataFrame.write")
+    else:
+        mock_writer = mocker.patch("pyspark.sql.DataFrame.write")
+
     mock_writer.format.return_value = mock_writer
     mock_writer.clusterBy.return_value = mock_writer
     mock_writer.mode.return_value = mock_writer

--- a/tests/spark/writers/delta/test_delta_writer.py
+++ b/tests/spark/writers/delta/test_delta_writer.py
@@ -574,12 +574,15 @@ def test_delta_table_writer_with_clustering(spark, mocker):
 
     writer = DeltaTableWriter(table=table_name, cluster_by=["col1", "col2"], df=df)
 
-    writer.writer
+    writer.execute()
     mock_writer.clusterBy.assert_called_once_with(["col1", "col2"])
 
 
-def test_cluster_by_validation(spark):
+def test_cluster_by_validation(spark, mocker):
     """Not running DeltaTableWriter with cluster_by specified in Databricks should raise an error"""
+
+    mocker.patch("koheesio.spark.writers.delta.batch.on_databricks", return_value=False)
+
     with pytest.raises(ValueError):
         DeltaTableWriter(table="test_table", cluster_by="col1", df=None)
 

--- a/tests/spark/writers/delta/test_delta_writer.py
+++ b/tests/spark/writers/delta/test_delta_writer.py
@@ -531,3 +531,60 @@ def test_merge_builder_type__invalid_merge_builder(mocker, spark):
             output_mode=BatchOutputMode.MERGE,
             output_mode_params={"merge_builder": merge_builder},
         )
+
+
+def test_delta_table_writer_with_clustering(spark, mocker):
+    # Pretending to be on Databricks
+    mocker.patch("koheesio.spark.writers.delta.batch.on_databricks", return_value=True)
+
+    # Mocking dataframe writer and methods called in write
+    mock_writer = mocker.patch("pyspark.sql.DataFrame.write")
+    mock_writer.format.return_value = mock_writer
+    mock_writer.clusterBy.return_value = mock_writer
+    mock_writer.mode.return_value = mock_writer
+
+    table_name = "test_cluster_by"
+    df = spark.createDataFrame(
+        [
+            (
+                "col1",
+                "col2",
+                "col3",
+                "col4",
+            ),
+            (
+                "col1",
+                "col2",
+                "col3",
+                "col4",
+            ),
+            (
+                "col1",
+                "col2",
+                "col3",
+                "col4",
+            ),
+        ],
+        schema=["col1", "col2", "col3", "col4"],
+    )
+
+    writer = DeltaTableWriter(table=table_name, cluster_by=["col1", "col2"], df=df)
+
+    writer.writer
+    mock_writer.clusterBy.assert_called_once_with(["col1", "col2"])
+
+
+def test_cluster_by_validation(spark):
+    """Not running DeltaTableWriter with cluster_by specified in Databricks should raise an error"""
+    with pytest.raises(ValueError):
+        DeltaTableWriter(table="test_table", cluster_by="col1", df=None)
+
+
+def test_validate_table_layout_parameters(spark):
+    """Only one of cluster by or partition by should be specified"""
+    with pytest.raises(ValueError):
+        DeltaTableWriter(
+            table="test_table",
+            cluster_by=["col1"],
+            partition_by=["col2"],
+        )


### PR DESCRIPTION
## Description
Adds support for clustering 

## Related Issue
https://github.com/Nike-Inc/koheesio/issues/214

## Motivation and Context
This will allow users to configure clustering when writing to a delta table that it does not exist yet.

## How Has This Been Tested?
Unit tests have been added

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
