### PR TITLE
feature - Function-based and decorator-based Spark transformations (RFC 225)

### DIFF
--- a/docs/reference/spark/transformations.md
+++ b/docs/reference/spark/transformations.md
@@ -39,7 +39,176 @@ requirements of your data pipeline.
 
 ## How to Define a Transformation
 
-To define a `Transformation`, you create a subclass of the `Transformation` class and implement the `execute` method.
+There are two ways to define a transformation: **subclassing** (traditional) and **function-based** (simpler for basic cases).
+
+### Function-Based Transformations
+
+For simple transformations, you can use `Transformation.from_func()` to create a transformation from a function without subclassing:
+
+```python
+from koheesio.spark.transformations import Transformation
+from pyspark.sql import functions as f
+
+# Define a function that transforms a DataFrame
+def lowercase_columns(df):
+    return df.select([f.col(c).alias(c.lower()) for c in df.columns])
+
+# Create a transformation from the function
+LowercaseColumns = Transformation.from_func(lowercase_columns)
+
+# Use it like any other transformation
+input_df = spark.createDataFrame([("John", 25)], ["NAME", "AGE"])
+output_df = LowercaseColumns().transform(input_df)
+# Result: columns are now ["name", "age"]
+```
+
+**Parameterized Transformations:**
+
+```python
+def add_audit_columns(df, user: str, system: str = "koheesio"):
+    return df.withColumn("created_by", f.lit(user)).withColumn("system", f.lit(system))
+
+AddAudit = Transformation.from_func(add_audit_columns)
+
+# Use with parameters
+output_df = AddAudit(user="pipeline_user", system="production").transform(input_df)
+```
+
+**Specialized Transformations with `.partial()`:**
+
+```python
+# Create a specialized version with preset parameters
+AddMyAudit = AddAudit.partial(user="my_pipeline", system="production")
+
+# Use without needing to pass parameters
+output_df = AddMyAudit().transform(input_df)
+```
+
+Function-based transformations are ideal for:
+- Simple DataFrame operations
+- Quick prototyping
+- When you don't need complex validation or computed properties
+
+### Decorator-Based Transformations
+
+For even more concise syntax with added type safety, you can use decorators to create transformations. Decorators are syntactic sugar over `.from_func()` that add Pydantic runtime type validation:
+
+```python
+from koheesio.spark.transformations import transformation, column_transformation, multi_column_transformation
+from pyspark.sql import Column, DataFrame
+from pyspark.sql import functions as f
+from koheesio.spark.utils import SparkDatatype
+
+# DataFrame transformation with type validation
+@transformation
+def filter_adults(df: DataFrame, min_age: int = 18) -> DataFrame:
+    return df.filter(f.col("age") >= min_age)
+
+# Type validation ensures min_age is int
+output_df = filter_adults(min_age=21).transform(input_df)
+
+# This raises ValidationError - type mismatch
+try:
+    output_df = filter_adults(min_age="21").transform(input_df)  # ❌ Error!
+except ValidationError:
+    print("Type validation caught the error!")
+
+# Column transformation with ColumnConfig
+@column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+def trim_strings(col: Column) -> Column:
+    return f.trim(col)
+
+# Automatically applies to all string columns
+output_df = trim_strings().transform(input_df)
+
+# Multi-column aggregation
+@multi_column_transformation
+def sum_quarters(q1: Column, q2: Column, q3: Column, q4: Column) -> Column:
+    return q1 + q2 + q3 + q4
+
+output_df = sum_quarters(
+    columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+    target_column="total_sales"
+).transform(input_df)
+```
+
+**Available Decorators:**
+
+1. **`@transformation`** - For DataFrame-level transformations
+   - Adds type validation to function parameters
+   - Equivalent to `Transformation.from_func()` with `validate_call`
+
+2. **`@column_transformation`** - For column-level transformations
+   - Supports all ColumnConfig parameters
+   - Auto-detects column-wise vs multi-column patterns
+   - Adds type validation
+
+3. **`@multi_column_transformation`** - For multi-column aggregations
+   - Explicitly sets multi-column mode (for_each=False)
+   - Ideal for N→1 aggregations
+   - Adds type validation
+
+**Type Validation Benefits:**
+
+```python
+@column_transformation
+def add_tax(amount: Column, rate: float) -> Column:
+    return amount * (1 + rate)
+
+# Valid: rate is float
+output_df = add_tax(columns=["price"], rate=0.08).transform(input_df)
+
+# Valid: list of floats (paired parameters)
+output_df = add_tax(
+    columns=["food", "non_food"],
+    rate=[0.08, 0.13]
+).transform(input_df)
+
+# Invalid: rate must be float or list of floats
+try:
+    output_df = add_tax(columns=["price"], rate="0.08").transform(input_df)
+except ValidationError as e:
+    print(f"Validation error: {e}")
+```
+
+**Disabling Validation:**
+
+For performance-critical code:
+
+```python
+@column_transformation(validate=False)
+def fast_transform(col: Column) -> Column:
+    return f.upper(col)
+```
+
+**Comparison: Decorator vs .from_func():**
+
+```python
+# Decorator syntax (with type safety)
+@column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+def to_upper(col: Column) -> Column:
+    return f.upper(col)
+
+# Equivalent .from_func() syntax (no automatic type safety)
+def to_upper_func(col: Column) -> Column:
+    return f.upper(col)
+
+ToUpper = ColumnsTransformation.from_func(
+    to_upper_func,
+    run_for_all_data_type=[SparkDatatype.STRING]
+)
+```
+
+Decorator-based transformations are ideal for:
+
+- When you want runtime type safety
+- When writing new transformations from scratch
+- When team consistency and clear intent are important
+- When you want IDE autocomplete and type hints
+
+### Subclassing Transformations
+
+For more complex transformations, you create a subclass of the `Transformation` class and implement the `execute` method.
 The `execute` method should take a DataFrame from `self.input.df`, apply a transformation, and store the result in
 `self.output.df`.
 
@@ -63,10 +232,233 @@ In this example, `MyTransformation` is a subclass of `Transformation` that you'v
 the data from `self.input.df`, applies a transformation called `apply_transformation` (undefined in this example), and
 stores the result in `self.output.df`.
 
+Subclassing is ideal for:
+
+- Complex validation logic
+- Computed properties or multiple methods
+- Orchestration of other transformations
+
 
 ## How to Define a ColumnsTransformation
 
-To define a `ColumnsTransformation`, you create a subclass of the `ColumnsTransformation` class and implement the 
+There are two ways to define a column transformation: **function-based** (simpler) and **subclassing** (for complex cases).
+
+### Function-Based Column Transformations
+
+For simple column operations, you can use `ColumnsTransformation.from_func()` to create a transformation from a function:
+
+```python
+from pyspark.sql import functions as f
+from koheesio.spark.transformations import ColumnsTransformation
+from koheesio.spark.utils import SparkDatatype
+
+# Create a transformation that lowercases string columns
+LowerCase = ColumnsTransformation.from_func(
+    lambda col: f.lower(col),
+    run_for_all_data_type=[SparkDatatype.STRING],
+    limit_data_type=[SparkDatatype.STRING]
+)
+
+# Example data
+input_df = spark.createDataFrame([("JOHN", "ENGINEER"), ("JANE", "MANAGER")], ["name", "title"])
+
+# Apply to specific column
+output_df = LowerCase(columns=["name"]).transform(input_df)
+# Result: name="john", title="ENGINEER" (unchanged)
+
+# Apply to all string columns automatically
+output_df = LowerCase().transform(input_df)
+# Result: name="john", title="engineer" (both lowercased)
+
+# With a target column (creates new column)
+output_df = LowerCase(columns=["name"], target_column="name_lower").transform(input_df)
+# Result: name="JOHN" (original), name_lower="john" (new)
+```
+
+**Parameterized Column Transformations:**
+
+```python
+def add_prefix(col, prefix: str):
+    return f.concat(f.lit(prefix), col)
+
+AddPrefix = ColumnsTransformation.from_func(add_prefix)
+
+# Use with parameter
+output_df = AddPrefix(columns=["name"], prefix="Mr. ").transform(input_df)
+# Result: name="Mr. JOHN"
+
+# Create a specialized version
+AddMrPrefix = AddPrefix.partial(prefix="Mr. ")
+output_df = AddMrPrefix(columns=["name"]).transform(input_df)
+# Same result, but don't need to pass prefix each time
+```
+
+**Factory Pattern for Related Transformations:**
+
+```python
+def string_transform(func):
+    """Factory for creating string column transformations."""
+    return ColumnsTransformation.from_func(
+        func,
+        run_for_all_data_type=[SparkDatatype.STRING],
+        limit_data_type=[SparkDatatype.STRING]
+    )
+
+# Create multiple related transformations
+LowerCase = string_transform(lambda col: f.lower(col))
+UpperCase = string_transform(lambda col: f.upper(col))
+TitleCase = string_transform(lambda col: f.initcap(col))
+
+# Use them
+output_df = (
+    input_df
+    .transform(LowerCase(columns=["name"], target_column="name_lower"))
+    .transform(UpperCase(columns=["name"], target_column="name_upper"))
+    .transform(TitleCase(columns=["name"], target_column="name_title"))
+)
+# Result: original name + name_lower, name_upper, name_title columns
+```
+
+**Multi-Column Aggregation (Pass All Columns at Once):**
+
+```python
+from pyspark.sql import Column
+
+# Sum multiple columns into one
+def sum_quarters(q1: Column, q2: Column, q3: Column, q4: Column) -> Column:
+    return q1 + q2 + q3 + q4
+
+SumQuarters = ColumnsTransformation.from_func(sum_quarters)
+
+input_df = spark.createDataFrame([(100, 200, 150, 250)], ["q1", "q2", "q3", "q4"])
+output_df = SumQuarters(
+    columns=["q1", "q2", "q3", "q4"],
+    target_column="yearly_total"
+).transform(input_df)
+# Result: yearly_total = 700 (all columns passed to function at once)
+
+# Concatenate columns
+def concat_names(first: Column, last: Column) -> Column:
+    return f.concat(first, f.lit(" "), last)
+
+ConcatNames = ColumnsTransformation.from_func(concat_names)
+output_df = ConcatNames(
+    columns=["first_name", "last_name"],
+    target_column="full_name"
+).transform(input_df)
+# Result: full_name = "John Doe"
+
+# Weighted sum with parameters
+def weighted_sum(q1: Column, q2: Column, q3: Column, q4: Column, weights: list) -> Column:
+    return q1*weights[0] + q2*weights[1] + q3*weights[2] + q4*weights[3]
+
+WeightedSum = ColumnsTransformation.from_func(weighted_sum)
+output_df = WeightedSum(
+    columns=["q1", "q2", "q3", "q4"],
+    weights=[0.1, 0.2, 0.3, 0.4],
+    target_column="weighted_total"
+).transform(input_df)
+```
+
+**Paired Parameters (Different Values Per Column):**
+
+```python
+# Apply different tax rates to different columns
+def add_tax(amount: Column, rate: float = 0.08) -> Column:
+    return amount * (1 + rate)
+
+AddTax = ColumnsTransformation.from_func(add_tax)
+
+input_df = spark.createDataFrame([(100.0, 200.0)], ["food_price", "non_food_price"])
+
+# Single rate for all columns (broadcast)
+output_df = AddTax(columns=["food_price", "non_food_price"], rate=0.08).transform(input_df)
+# Result: Both columns get 8% tax
+
+# Different rate per column (paired parameters)
+output_df = AddTax(
+    columns=["food_price", "non_food_price"],
+    rate=[0.08, 0.13]  # Must match column count (strict=True)
+).transform(input_df)
+# Result: food_price gets 8% tax (108.0), non_food_price gets 13% tax (226.0)
+
+# Multiple paired parameters
+def scale_and_offset(col: Column, scale: float, offset: float) -> Column:
+    return col * scale + offset
+
+ScaleOffset = ColumnsTransformation.from_func(scale_and_offset)
+output_df = ScaleOffset(
+    columns=["temp_c", "pressure_kpa"],
+    scale=[1.8, 0.145],      # Celsius to Fahrenheit, kPa to PSI
+    offset=[32.0, 0.0]
+).transform(input_df)
+```
+
+**Important:** List parameters must exactly match the number of columns (like Python's `zip(..., strict=True)`). If the list length doesn't match, a `ValueError` is raised.
+
+```python
+# ❌ This will raise ValueError
+AddTax(columns=["a", "b", "c"], rate=[0.08, 0.13])
+# ValueError: Parameter 'rate' has 2 values but 3 columns provided.
+
+# ✅ Fix: match the count
+AddTax(columns=["a", "b", "c"], rate=[0.08, 0.13, 0.13])
+
+# ✅ Or use single value
+AddTax(columns=["a", "b", "c"], rate=0.08)
+```
+
+**Variadic Support (Any Number of Columns):**
+
+```python
+from functools import reduce
+
+# Variadic *args - any number of columns
+def sum_columns(*cols: Column) -> Column:
+    return reduce(lambda a, b: a + b, cols)
+
+SumColumns = ColumnsTransformation.from_func(sum_columns)
+
+# Works with any number of columns
+output_df = SumColumns(columns=["jan", "feb", "mar"], target_column="q1_total").transform(input_df)
+output_df = SumColumns(columns=["q1", "q2", "q3", "q4"], target_column="yearly_total").transform(input_df)
+```
+
+**Two Methods for Different Use Cases:**
+
+Koheesio provides two methods for creating column transformations:
+
+1. **`from_func()`** - Defaults to column-wise behavior when ambiguous
+   - Best for: Simple column operations, string transformations, element-wise math
+   - Auto-detects multi-column when type hints indicate multiple Column parameters
+
+2. **`from_multi_column_func()`** - Defaults to multi-column behavior when ambiguous
+   - Best for: Aggregations, concatenations, combining multiple columns
+   - Auto-detects column-wise when type hints indicate single Column parameter
+
+**Explicit Override:**
+```python
+# Force column-wise
+Transform = ColumnsTransformation.from_func(some_func, for_each=True)
+
+# Force multi-column
+Transform = ColumnsTransformation.from_func(some_func, for_each=False)
+```
+
+**Pattern Detection:**
+
+| Function Signature | Auto-Detected | from_func() default | from_multi_column_func() default |
+|-------------------|---------------|---------------------|----------------------------------|
+| `func(col: Column)` | Column-wise | ✅ Column-wise | ✅ Column-wise (overrides) |
+| `func(c1: Column, c2: Column)` | Multi-column | ✅ Multi-column (overrides) | ✅ Multi-column |
+| `func(*cols: Column)` | Multi-column | ✅ Multi-column | ✅ Multi-column |
+| `func(col: Column, rate: float)` | Column-wise | ✅ Column-wise | ✅ Column-wise (overrides) |
+| `lambda col: ...` | Ambiguous | ⚠️ Column-wise | ⚠️ Multi-column |
+| `lambda a, b: ...` | Ambiguous | ⚠️ Column-wise | ⚠️ Multi-column |
+
+### Subclassing ColumnsTransformation
+
+For more complex column transformations, you create a subclass of the `ColumnsTransformation` class and implement the 
 `execute` method. The `execute` method should apply a transformation to the specified columns of the DataFrame.
 
 `ColumnsTransformation` classes can be easily swapped out for different data transformations without changing the rest 
@@ -87,15 +479,39 @@ class AddOne(ColumnsTransformation):
 In this example, `AddOne` is a subclass of `ColumnsTransformation` that you've defined. The `execute` method adds 1 to
 each column in `self.get_columns()`.
 
-The `ColumnsTransformation` class has a `ColumnConfig` class that can be used to configure the behavior of the class.
-This class has the following fields:
+### ColumnConfig Parameters
 
-- `run_for_all_data_type`: Allows to run the transformation for all columns of a given type.
-- `limit_data_type`: Allows to limit the transformation to a specific data type.
-- `data_type_strict_mode`: Toggles strict mode for data type validation. Will only work if `limit_data_type` is set.
+The `ColumnsTransformation` class supports configuration parameters for controlling column selection and validation:
 
-Note that data types need to be specified as a `SparkDatatype` enum. Users should not have to interact with the
-`ColumnConfig` class directly.
+- `run_for_all_data_type`: Automatically select all columns of specified data types when no columns are provided
+- `limit_data_type`: Restrict the transformation to specific data types
+- `data_type_strict_mode`: When True, raises an error if a column doesn't match `limit_data_type`; when False, shows a warning and skips the column
+
+Data types are specified using the `SparkDatatype` enum.
+
+For function-based transformations, pass these as parameters to `from_func()`:
+
+```python
+LowerCase = ColumnsTransformation.from_func(
+    lambda col: f.lower(col),
+    run_for_all_data_type=[SparkDatatype.STRING],
+    limit_data_type=[SparkDatatype.STRING],
+    data_type_strict_mode=True
+)
+```
+
+For subclasses, define them in a nested `ColumnConfig` class:
+
+```python
+class LowerCase(ColumnsTransformationWithTarget):
+    class ColumnConfig:
+        run_for_all_data_type = [SparkDatatype.STRING]
+        limit_data_type = [SparkDatatype.STRING]
+        data_type_strict_mode = False
+    
+    def func(self, column):
+        return f.lower(column)
+```
 
 
 ## How to Define a ColumnsTransformationWithTarget
@@ -209,34 +625,287 @@ In this example, `HashUUID5` is a subclass of `Transformation`. After creating a
 the `execute` method to apply the transformation. The `execute` method generates a UUID5 hash for each row in the
 DataFrame based on the values of the `id` and `value` columns and stores the result in a new column named `hash`.
 
-## Benefits of using Koheesio Transformations
+## Why Choose Koheesio Over Raw PySpark?
 
-Using a Koheesio `Transformation` over plain Spark provides several benefits:
+Using Koheesio `Transformation` classes over raw PySpark provides compelling benefits that become especially apparent in team environments and production pipelines:
 
-1. **Consistency**: By using `Transformation` classes, you ensure that data is transformed in a consistent manner
-    across different parts of your pipeline. This can help avoid errors and make your code easier to understand and
-    maintain.
+### 1. **Reusability & Team Libraries**
 
-2. **Abstraction**: `Transformation` classes abstract away the details of transforming data, allowing you to focus on
-    the logic of your pipeline. This can make your code cleaner and easier to read.
+**Raw PySpark** requires copying transformation logic across files:
 
-3. **Flexibility**: `Transformation` classes can be easily swapped out for different data transformations without
-    changing the rest of your pipeline. This can make your pipeline more flexible and easier to modify or extend.
+```python
+# Repeated everywhere you need to uppercase strings
+df = df.withColumn("name", f.upper(f.col("name")))
+df = df.withColumn("city", f.upper(f.col("city")))
+```
 
-4. **Early Input Validation**: As a `Transformation` is a type of `SparkStep`, which in turn is a `Step` and a type of
-    Pydantic `BaseModel`, all inputs are validated when an instance of a `Transformation` class is created. This early
-    validation helps catch errors related to invalid input, such as an invalid column name, before the PySpark pipeline
-    starts executing. This can help avoid unnecessary computation and make your data pipelines more robust and reliable.
+**Koheesio** lets you build reusable transformation libraries:
 
-5. **Ease of Testing**: `Transformation` classes are designed to be easily testable. This can make it easier to write
-    unit tests for your data pipeline, helping to ensure its correctness and reliability.
+```python
+# Define once
+@column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+def to_upper(col: Column) -> Column:
+    return f.upper(col)
 
-6. **Robustness**: Koheesio has been extensively tested with hundreds of unit tests, ensuring that the `Transformation`
-    classes work as expected under a wide range of conditions. This makes your data pipelines more robust and less
-    likely to fail due to unexpected inputs or edge cases.
+# Reuse everywhere - applies to ALL string columns automatically
+outp1_df = to_upper().transform(input_df)
+# While still being able to use it on select columns as well
+outp2_df = to_upper(column="foo").transform(input_df)
+```
 
-By using the concept of a `Transformation`, you can create data pipelines that are simple, consistent, flexible,
-efficient, and reliable.
+**Value:** Build a library of transformations your entire team can reuse. No more copy-pasting.
+
+### 2. **Automatic Column Type Filtering (ColumnConfig)**
+
+**Raw PySpark** requires manual type checking:
+
+```python
+# Manual iteration and type checking
+for col_name, dtype in df.dtypes:
+    if dtype == 'string':
+        df = df.withColumn(col_name, f.trim(f.col(col_name)))
+```
+
+**Koheesio** automates type-based operations:
+
+```python
+@column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+def trim_strings(col: Column) -> Column:
+    return f.trim(col)
+
+trim_strings().transform(df)  # Automatically finds and processes all string columns
+```
+
+**Value:** Eliminate boilerplate for type-based column operations.
+
+### 3. **Parameter Validation & Fail-Fast Errors**
+
+**Raw PySpark** allows silent data corruption:
+
+```python
+def add_tax(df, columns, rates):
+    # Silent truncation if lengths don't match!
+    for col, rate in zip(columns, rates):
+        df = df.withColumn(col, f.col(col) * (1 + rate))
+    return df
+
+# This silently ignores the third column - no error!
+add_tax(df, ["food", "non_food", "beverage"], [0.08, 0.13])
+```
+
+**Koheesio** enforces strict validation:
+
+```python
+@column_transformation
+def add_tax(amount: Column, rate: float) -> Column:
+    return amount * (1 + rate)
+
+# Clear error with strict zip semantics
+AddTax(columns=["food", "non_food", "beverage"], rate=[0.08, 0.13])
+# ValueError: Parameter 'rate' has 2 values but 3 columns provided.
+# Lists must match column count exactly (like Python's zip(..., strict=True)).
+```
+
+**Value:** Fail fast with clear errors instead of silent data corruption.
+
+### 4. **Consistent, Focused Unit Tests**
+
+Both raw PySpark code and Koheesio transformations ultimately operate on Spark `DataFrame`s and `Column`s, so you still
+need a Spark session and test data either way. The difference is *how easy it is to isolate and reuse the logic you
+want to test*.
+
+```python
+# Raw PySpark: logic often lives inside larger pipelines
+def complex_pipeline(df):
+    df = df.withColumn("x", f.col("a") + f.col("b"))
+    df = df.withColumn("y", f.col("x") * 2)
+    df = df.filter(f.col("y") > 10)
+    return df
+```
+
+With Koheesio, you are encouraged to put reusable logic behind a small, well‑named transformation:
+
+```python
+@multi_column_transformation
+def add_columns(a: Column, b: Column) -> Column:
+    return a + b
+
+def test_add_columns(spark):
+    df = spark.createDataFrame([(1, 2)], ["a", "b"])
+    result = add_columns(columns=["a", "b"], target_column="sum").transform(df)
+    assert result.select("sum").first()[0] == 3
+```
+
+**Value:** Transformations share a common interface (`.transform(df)`), making it natural to write small, consistent
+tests that focus on a single piece of logic, even though Spark is still involved.
+
+### 5. **Declarative Intent & Self-Documenting Code**
+
+**Raw PySpark** requires reading implementation to understand intent:
+
+```python
+# What does this do? You have to read the code
+def process_data(df):
+    return df.withColumn("total", 
+        f.col("q1") + f.col("q2") + f.col("q3") + f.col("q4"))
+```
+
+**Koheesio** makes intent crystal clear:
+
+```python
+@multi_column_transformation
+def sum_quarters(q1: Column, q2: Column, q3: Column, q4: Column) -> Column:
+    """Sum quarterly sales into annual total."""
+    return q1 + q2 + q3 + q4
+
+# Self-documenting - intent is obvious
+SumQuarters(
+    columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+    target_column="annual_sales"
+).transform(df)
+```
+
+**Value:** Code documents itself. The decorator and class name tell you what it does.
+
+Optionally, the `name` and `description` fields can be used to further clarify your code:
+
+```python
+SumQuarters(
+    name="annual_sales_sum",
+    description="Sum Q1–Q4 into annual_sales for reporting",
+    columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+    target_column="annual_sales",
+).transform(df)
+```
+
+All Koheesio transformation instances have a `name` field: by default it is derived from the class name (which, for
+`.from_func()` and decorator-based transformations, comes from the original function name), and you can override it
+per-instance via `name="..."` when needed.
+
+### 6. **Factory Patterns for Related Transformations**
+
+You *can* build DRY helpers in raw PySpark, but they tend to remain ad‑hoc functions:
+
+```python
+def string_transform(func):
+    def apply(df, columns):
+        for col in columns:
+            df = df.withColumn(col, func(f.col(col)))
+        return df
+
+    return apply
+
+to_lower = string_transform(lambda c: f.lower(c))
+to_upper = string_transform(lambda c: f.upper(c))
+title_case = string_transform(lambda c: f.initcap(c))
+```
+
+With Koheesio, the same idea produces **first-class transformations** that plug into the rest of the framework:
+
+```python
+def string_transform(func):
+    return ColumnsTransformation.from_func(
+        func,
+        run_for_all_data_type=[SparkDatatype.STRING],
+        limit_data_type=[SparkDatatype.STRING],
+    )
+
+LowerCase = string_transform(lambda col: f.lower(col))
+UpperCase = string_transform(lambda col: f.upper(col))
+TitleCase = string_transform(lambda col: f.initcap(col))
+
+df = spark.createDataFrame([(" Alice ", "Smith ")], ["first_name", "last_name"])
+
+# Because these are ColumnsTransformation classes, you get:
+# - ColumnConfig behaviour (run_for_all_data_type / limit_data_type)
+# - A uniform .transform(df) interface
+# - Optional name/description metadata
+cleaned = LowerCase(
+    name="normalize_names",
+    description="Lowercase all string columns",
+).transform(df)
+```
+
+**Value:** Reusable factories create properly-typed `ColumnsTransformation` classes that participate fully in Koheesio
+pipelines (ColumnConfig, validation, metadata, composition) instead of remaining one-off helper functions.
+
+### 7. **Team Consistency & Standardization**
+
+**Raw PySpark** leads to inconsistent styles:
+
+```python
+# Engineer A's style
+df.withColumn("result", f.col("a") + f.col("b"))
+
+# Engineer B's style  
+df.select("*", (f.col("a") + f.col("b")).alias("result"))
+
+# Engineer C's style
+def add_cols(a: Column, b: Column) -> Column:
+    return a + b
+df.withColumn("result", add_cols(f.col("a"), f.col("b")))
+```
+
+**Koheesio** enforces consistent patterns:
+
+```python
+# Everyone uses the same pattern
+@column_transformation
+def add_columns(a: Column, b: Column) -> Column:
+    return a + b
+
+# Consistent usage across the team
+AddColumns(columns=["a", "b"], target_column="result").transform(df)
+```
+
+**Value:** Standardized patterns make code reviews easier and onboarding faster.
+
+### 8. **Early Input Validation**
+
+As a `Transformation` is a type of `SparkStep`, which in turn is a `Step` and a type of Pydantic `BaseModel`, all inputs are validated when an instance of a `Transformation` class is created. This early validation helps catch errors related to invalid input, such as an invalid column name, before the PySpark pipeline starts executing. This can help avoid unnecessary computation and make your data pipelines more robust and reliable.
+
+### 9. **Production-Grade Robustness**
+
+Koheesio has been extensively tested with hundreds of unit tests. The `Transformation` classes are validated under a wide range of conditions, making your data pipelines more robust and less likely to fail due to unexpected inputs or edge cases. You don't need to re‑test Koheesio's core behavior in every project (except for your own business logic) so you can iterate faster.
+
+### The Decorator Advantage
+
+With v0.11's decorator-based transformations, **the barrier to entry is now as low as raw PySpark**:
+
+```python
+# Before: Had to write a class
+class AddTax(ColumnsTransformationWithTarget):
+    rate: float = 0.08
+    def func(self, col):
+        return col * (1 + self.rate)
+
+# After: Just decorate a function
+@column_transformation
+def add_tax(col: Column, rate: float = 0.08) -> Column:
+    return col * (1 + rate)
+```
+
+**Key Insight:** Decorators make Koheesio **as easy to write as raw PySpark**, but with enterprise-grade benefits (reusability, type safety, ColumnConfig, testability, team consistency) for free.
+
+### When to Use Raw PySpark
+
+Raw PySpark is better for:
+
+- **One-off scripts** where you'll never reuse the logic
+- **Extremely simple operations** (single `withColumn` call)
+- **Performance-critical hot paths** where abstraction overhead matters
+- **Solo development** where team consistency isn't needed
+
+### Summary
+
+By using Koheesio `Transformation` classes, you can create data pipelines that are:
+
+- **Reusable** - Build libraries, not copy-paste code
+- **Type-Safe** - Fail fast with clear errors
+- **Testable** - Unit test transformations in isolation
+- **Declarative** - Self-documenting code
+- **Consistent** - Standardized patterns across teams
+- **Robust** - Production-tested and reliable
 
 ## Advanced Usage of Transformations
 

--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -2,11 +2,33 @@
 
 Version 0.11 is Koheesio's 5th release since getting Open Sourced.
 
-This version brings important bug fixes and improvements to the core Context module. The overall API remains unchanged.
+This version introduces function-based transformations as a simpler alternative to subclassing for simple 
+transformations, while maintaining 100% backward compatibility. It also includes important bug fixes and improvements 
+to the core Context module.
 
 ## Migrating from v0.10
 
-For users currently using v0.10, no breaking changes have been introduced. This release focuses on bug fixes and stability improvements.
+For users currently using v0.10, no breaking changes have been introduced. All existing code continues to work 
+unchanged. Some powerful new patterns have been added though - we encourage you to check out the new functionality.
+
+### New Features
+
+* **Function-Based Transformations** - Create transformations from functions without subclassing:
+  * `Transformation.from_func()` - Create DataFrame-level transformations from functions
+  * `ColumnsTransformation.from_func()` - Create column-level transformations with full ColumnConfig support
+  * `@transformation`, `@column_transformation`, `@multi_column_transformation` decorators for Pythonic syntax
+  * Reduces code by 80-95% for simple transformations
+  * **As easy to write as raw PySpark, but with enterprise-grade benefits** (reusability, type safety, testability)
+  * See the [Function-Based Transformations tutorial](../tutorials/function-based-transformations.md) for examples
+
+### Deprecations
+
+* **Transform Class** - The `Transform` class is now deprecated in favor of `Transformation.from_func()`:
+* **ColumnsTransformationWithTarget** - The `ColumnsTransformationWithTarget` class is now deprecated in favor of
+  the `ColumnsTransformation` class:
+
+Both will be removed in v1.0. See migration examples in the tutorial
+
 
 ## Release 0.11.0
 
@@ -14,6 +36,417 @@ For users currently using v0.10, no breaking changes have been introduced. This 
 
 * **Full Changelog**:
     <https://github.com/Nike-Inc/koheesio/compare/koheesio-v0.10.6...koheesio-v0.11.0>
+
+### Features
+
+!!! feat "feature - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related discussion [#225](https://github.com/Nike-Inc/koheesio/discussions/225)"
+    #### *Spark > Transformations*: Function-Based Transformations
+
+    Introduced function-based transformations as a simpler alternative to subclassing for simple transformations.
+
+    **New Methods:**
+
+    * `Transformation.from_func(func, **kwargs)` - Create DataFrame-level transformations from functions
+    * `ColumnsTransformation.from_func(func, for_each=None, **kwargs)` - Create column-level transformations (defaults to column-wise)
+    * `ColumnsTransformation.from_multi_column_func(func, for_each=None, **kwargs)` - Create multi-column transformations (defaults to multi-column)
+
+    **Benefits:**
+
+    * **Code Reduction**: 80-95% less code for simple transformations
+    * **Easier to Write**: No class definitions needed for simple cases
+    * **Factory Patterns**: Create related transformations easily
+    * **Full ColumnConfig Support**: Type validation and automatic column selection
+    * **Backward Compatible**: All existing code continues to work
+
+    **Before (v0.10) - Subclassing:**
+    ```python
+    from koheesio.spark.transformations import ColumnsTransformationWithTarget
+    from koheesio.spark.utils import SparkDatatype
+    from pyspark.sql import functions as f
+    
+    class LowerCase(ColumnsTransformationWithTarget):
+        class ColumnConfig:
+            run_for_all_data_type = [SparkDatatype.STRING]
+            limit_data_type = [SparkDatatype.STRING]
+        
+        def func(self, column):
+            return f.lower(column)
+    
+    # Usage
+    output_df = LowerCase(columns=["name"]).transform(input_df)
+    ```
+
+    **After (v0.11) - Function-Based:**
+    ```python
+    from koheesio.spark.transformations import ColumnsTransformation
+    from koheesio.spark.utils import SparkDatatype
+    from pyspark.sql import functions as f
+    
+    LowerCase = ColumnsTransformation.from_func(
+        lambda col: f.lower(col),
+        run_for_all_data_type=[SparkDatatype.STRING],
+        limit_data_type=[SparkDatatype.STRING]
+    )
+    
+    # Usage (same as before)
+    output_df = LowerCase(columns=["name"]).transform(input_df)
+    ```
+
+    **Factory Pattern Example:**
+    ```python
+    # v0.10: Would need 3 separate class definitions
+    # v0.11: Create multiple transformations in 4 lines
+    
+    def string_transform(func):
+        return ColumnsTransformation.from_func(
+            func,
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING]
+        )
+    
+    LowerCase = string_transform(lambda col: f.lower(col))
+    UpperCase = string_transform(lambda col: f.upper(col))
+    TitleCase = string_transform(lambda col: f.initcap(col))
+    ```
+
+    **DataFrame Transformation Example:**
+    ```python
+    # v0.10: Would use Transform class (now deprecated)
+    # v0.11: Use Transformation.from_func()
+    
+    def lowercase_columns(df):
+        return df.select([f.col(c).alias(c.lower()) for c in df.columns])
+    
+    LowercaseColumns = Transformation.from_func(lowercase_columns)
+    output_df = LowercaseColumns().transform(input_df)
+    ```
+
+    **Multi-Column Aggregation Example:**
+    ```python
+    # Sum multiple columns into one
+    from pyspark.sql import Column
+    
+    def sum_quarters(q1: Column, q2: Column, q3: Column, q4: Column) -> Column:
+        return q1 + q2 + q3 + q4
+    
+    # Option A: from_func() - auto-detects multi-column from type hints
+    SumQuarters = ColumnsTransformation.from_func(sum_quarters)
+    output_df = SumQuarters(
+        columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+        target_column="total_sales"
+    ).transform(input_df)
+    # Result: Passes all 4 columns to function at once
+    
+    # Option B: from_multi_column_func() - makes intent explicit
+    SumQuarters = ColumnsTransformation.from_multi_column_func(sum_quarters)
+    # Same behavior, but method name makes it clear this is multi-column
+    
+    # Concatenate columns
+    def concat_names(first: Column, last: Column) -> Column:
+        return f.concat(first, f.lit(" "), last)
+    
+    ConcatNames = ColumnsTransformation.from_func(concat_names)
+    output_df = ConcatNames(
+        columns=["first_name", "last_name"],
+        target_column="full_name"
+    ).transform(input_df)
+    ```
+
+    **Paired Parameters Example (Different Values Per Column):**
+    ```python
+    # Apply different tax rates to different columns
+    def add_tax(amount: Column, rate: float = 0.08) -> Column:
+        return amount * (1 + rate)
+    
+    AddTax = ColumnsTransformation.from_func(add_tax)
+    
+    # Single rate for all columns
+    output_df = AddTax(columns=["price", "cost"], rate=0.08).transform(input_df)
+    
+    # Different rate per column (paired parameters)
+    output_df = AddTax(
+        columns=["food_price", "non_food_price"],
+        rate=[0.08, 0.13]  # Must match column count (strict=True)
+    ).transform(input_df)
+    # Result: food_price gets 8% tax, non_food_price gets 13% tax
+    
+    # Multiple paired parameters
+    def scale_and_offset(col: Column, scale: float, offset: float) -> Column:
+        return col * scale + offset
+    
+    ScaleOffset = ColumnsTransformation.from_func(scale_and_offset)
+    ScaleOffset(
+        columns=["temp_c", "pressure_kpa"],
+        scale=[1.8, 0.145],      # Celsius to Fahrenheit, kPa to PSI
+        offset=[32.0, 0.0]
+    )
+    ```
+
+    **Important:** List parameters must exactly match the number of columns (like Python's `zip(..., strict=True)`). If you need the same value for all columns, pass a single value instead of a list.
+
+    **Variadic Support (Any Number of Columns):**
+    ```python
+    from functools import reduce
+    
+    # Variadic *args - any number of columns
+    def sum_columns(*cols: Column) -> Column:
+        return reduce(lambda a, b: a + b, cols)
+    
+    SumColumns = ColumnsTransformation.from_func(sum_columns)
+    
+    # Works with any number of columns
+    SumColumns(columns=["jan", "feb", "mar"], target_column="q1_total")
+    SumColumns(columns=["q1", "q2", "q3", "q4"], target_column="yearly_total")
+    ```
+
+    **Two Methods for Different Defaults:**
+    
+    - `from_func()` - Defaults to column-wise (for_each=True) when ambiguous
+    - `from_multi_column_func()` - Defaults to multi-column (for_each=False) when ambiguous
+    - Both methods auto-detect from type hints when available
+    - Use `for_each` parameter to explicitly override: `from_func(func, for_each=False)`
+    
+    **Pattern Detection:**
+    
+    The implementation automatically detects the pattern based on function signature:
+    
+    | Function Signature | Detected Pattern | from_func() | from_multi_column_func() |
+    |-------------------|------------------|-------------|--------------------------|
+    | `func(col: Column)` | Column-wise (auto) | ✅ Column-wise | ✅ Column-wise (overrides default) |
+    | `func(c1: Column, c2: Column)` | Multi-column (auto) | ✅ Multi-column (overrides default) | ✅ Multi-column |
+    | `func(*cols: Column)` | Multi-column (auto) | ✅ Multi-column | ✅ Multi-column |
+    | `func(col: Column, rate: float)` | Column-wise (auto) | ✅ Column-wise | ✅ Column-wise (overrides default) |
+    | `lambda col: ...` | Ambiguous | ⚠️ Column-wise (default) | ⚠️ Multi-column (default) |
+    | `lambda a, b: ...` | Ambiguous | ⚠️ Column-wise (default) | ⚠️ Multi-column (default) |
+    
+    **Recommendation:** Use type hints for auto-detection, or choose the method that matches your intent for lambdas.
+
+    **When to Use Function-Based:**
+
+    * Simple column operations (0-2 parameters, pure functions)
+    * DataFrame transformations without complex validation
+    * Factory patterns for related transformations
+
+    **When to Keep Subclassing:**
+
+    * Complex validation logic
+    * Computed properties or multiple methods
+    * Orchestration of other transformations
+
+    **Implementation Note:**
+
+    ColumnConfig parameters (`run_for_all_data_type`, `limit_data_type`, `data_type_strict_mode`) are now also available as Pydantic fields on `ColumnsTransformation`, allowing function-based transformations to leverage them naturally while maintaining 100% backward compatibility with existing subclasses that use the nested `ColumnConfig` class.
+
+    **Looking Ahead to v1.0:**
+
+    This release lays the groundwork for v1.0, where function-based transformations will become the primary pattern for simple transformations. In v1.0, we plan to:
+    
+    * Remove the deprecated `Transform` and `ColumnsTransformationWithTarget` classes (functionality is now available via `.from_func()` methods)
+    * Migrate Koheesio's built-in simple transformations to use `.from_func()` (or decorator patterns) where appropriate 
+    * Remove the nested `ColumnConfig` class in favor of the field-based approach
+
+    For more details on the design and rationale, see [RFC #225](https://github.com/Nike-Inc/koheesio/discussions/225).
+
+    See the [Function-Based Transformations tutorial](../tutorials/function-based-transformations.md) for comprehensive examples and migration guidance.
+
+    <small> by @dannymeijer </small>
+
+!!! feat "feature - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related discussion [#225](https://github.com/Nike-Inc/koheesio/discussions/225)"
+    #### *Spark > Transformations*: Decorator-Based Transformations with Type Safety
+
+    Added decorator-based syntax for defining Spark transformations, built on top of the existing `.from_func()` APIs
+    with Pydantic-powered runtime validation.
+
+    **New decorators:**
+
+    - `@transformation` – DataFrame-level transformations with parameter validation.
+    - `@column_transformation` – Column-level transformations with full ColumnConfig support.
+    - `@multi_column_transformation` – Multi-column aggregations (N→1) with type validation.
+
+    **Why it matters:**
+
+    - Clear, declarative intent (e.g. `@column_transformation` signals column-level ops).
+    - Reusable, testable transformation classes instead of ad‑hoc helper functions.
+    - Shared patterns and validation across teams.
+
+    For examples and advanced usage (paired parameters, variadic functions, factory patterns), see the
+    [Decorator-Based Transformations reference](../reference/spark/transformations.md#decorator-based-transformations).
+
+    <small> by @dannymeijer </small>
+
+!!! info "Why Choose Koheesio Over Raw PySpark?"
+    #### The Value Proposition
+
+    With v0.11's decorator-based transformations, **Koheesio is now as easy to write as raw PySpark**, but provides 
+    enterprise-grade benefits that become critical in team environments and production pipelines:
+
+    **1. Reusability & Team Libraries**
+    ```python
+    # Raw PySpark: Copy-paste everywhere
+    df = df.withColumn("name", f.upper(f.col("name")))
+    df = df.withColumn("city", f.upper(f.col("city")))
+    
+    # Koheesio: Define once, reuse everywhere
+    @column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+    def to_upper(col: Column) -> Column:
+        return f.upper(col)
+    
+    to_upper().transform(df)  # Applies to ALL string columns
+    ```
+
+    **2. Fail-Fast Error Detection**
+    ```python
+    # Raw PySpark: Silent data corruption
+    for col, rate in zip(columns, rates):  # Silently truncates!
+        df = df.withColumn(col, f.col(col) * (1 + rate))
+    
+    # Koheesio: Clear errors (strict zip semantics)
+    AddTax(columns=["a", "b", "c"], rate=[0.08, 0.13])
+    # ValueError: Parameter 'rate' has 2 values but 3 columns provided.
+    ```
+
+    **3. Easy Unit Testing**
+    ```python
+    # Koheesio transformations are independently testable
+    @column_transformation
+    def add_tax(amount: Column, rate: float) -> Column:
+        return amount * (1 + rate)
+    
+    def test_add_tax(spark):
+        df = spark.createDataFrame([(100.0,)], ["price"])
+        result = add_tax(columns=["price"], rate=0.08).transform(df)
+        assert result.select("price").first()[0] == 108.0
+    ```
+
+    **4. Self-Documenting Code**
+    ```python
+    # Intent is crystal clear
+    @multi_column_transformation
+    def sum_quarters(q1: Column, q2: Column, q3: Column, q4: Column) -> Column:
+        """Sum quarterly sales into annual total."""
+        return q1 + q2 + q3 + q4
+    
+    SumQuarters(
+        columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+        target_column="annual_sales"
+    )
+    ```
+
+    **5. Factory Patterns (DRY)**
+    ```python
+    # Create 3 transformations in 6 lines
+    def string_transform(func):
+        return ColumnsTransformation.from_func(
+            func, run_for_all_data_type=[SparkDatatype.STRING]
+        )
+    
+    LowerCase = string_transform(lambda col: f.lower(col))
+    UpperCase = string_transform(lambda col: f.upper(col))
+    TitleCase = string_transform(lambda col: f.initcap(col))
+    ```
+
+    **6. Team Consistency**
+    
+    Everyone uses the same standardized patterns, making code reviews easier and onboarding faster.
+
+    **The Key Insight:** Decorators lower the barrier to entry to raw PySpark levels, while providing reusability, type safety, ColumnConfig automation, testability, and team consistency for free.
+
+    **When to Use Raw PySpark:** One-off scripts, extremely simple operations, performance-critical hot paths, or solo development where team consistency isn't needed.
+
+### Deprecations
+
+!!! warning "deprecation - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related discussion [#225](https://github.com/Nike-Inc/koheesio/discussions/225)"
+    #### *Spark > Transformations*: Transform Class Deprecated
+
+    The `Transform` class is now deprecated in favor of `Transformation.from_func()`.
+
+    **Migration:**
+    ```python
+    # Old (v0.10) - using Transform
+    from koheesio.spark.transformations.transform import Transform
+    
+    transform = Transform(func=some_func, a="foo", b="bar")
+    
+    # New (v0.11+) - using Transformation.from_func()
+    from koheesio.spark.transformations import Transformation
+    
+    SomeFunc = Transformation.from_func(some_func)
+    transform = SomeFunc(a="foo", b="bar")
+    ```
+
+    **Timeline:**
+
+    * v0.11: Deprecation warning shown when using `Transform`
+    * v1.0: `Transform` class will be removed
+
+    <small> by @dannymeijer </small>
+
+!!! warning "deprecation - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related discussion [#225](https://github.com/Nike-Inc/koheesio/discussions/225)"
+    #### *Spark > Transformations*: ColumnsTransformationWithTarget Deprecated
+
+    The `ColumnsTransformationWithTarget` class is now deprecated in favor of `ColumnsTransformation.from_func()`.
+
+    **Migration:**
+    ```python
+    # Old (v0.10) - using ColumnsTransformationWithTarget
+    from koheesio.spark.transformations import ColumnsTransformationWithTarget
+    from pyspark.sql import functions as f
+    
+    class MyTransform(ColumnsTransformationWithTarget):
+        def func(self, col):
+            return f.lower(col)
+    
+    # New (v0.11+) - using ColumnsTransformation.from_func()
+    from koheesio.spark.transformations import ColumnsTransformation
+    from pyspark.sql import functions as f
+    
+    MyTransform = ColumnsTransformation.from_func(lambda col: f.lower(col))
+    ```
+
+    **Timeline:**
+
+    * v0.11: Deprecation warning shown when subclassing `ColumnsTransformationWithTarget`
+    * v1.0: `ColumnsTransformationWithTarget` class will be removed
+
+    <small> by @dannymeijer </small>
+
+!!! warning "deprecation - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related discussion [#225](https://github.com/Nike-Inc/koheesio/discussions/225)"
+    #### *Spark > Transformations*: Nested ColumnConfig Deprecated
+
+    Using nested `ColumnConfig` classes is now deprecated in favor of using the field-based approach.
+
+    **Migration:**
+    ```python
+    # Old (v0.10) - using nested ColumnConfig
+    from koheesio.spark.transformations import ColumnsTransformation
+    from koheesio.spark.utils import SparkDatatype
+    
+    class MyTransform(ColumnsTransformation):
+        class ColumnConfig:
+            run_for_all_data_type = [SparkDatatype.STRING]
+            limit_data_type = [SparkDatatype.STRING]
+        
+        def execute(self):
+            # transformation logic
+            pass
+    
+    # New (v0.11+) - using field-based approach
+    from koheesio.spark.transformations import ColumnsTransformation
+    from koheesio.spark.utils import SparkDatatype
+    
+    MyTransform = ColumnsTransformation.from_func(
+        lambda col: f.lower(col),
+        run_for_all_data_type=[SparkDatatype.STRING],
+        limit_data_type=[SparkDatatype.STRING]
+    )
+    ```
+
+    **Timeline:**
+
+    * v0.11: Deprecation warning shown when nested `ColumnConfig` is accessed
+    * v1.0: Nested `ColumnConfig` class will be removed
+
+    <small> by @dannymeijer </small>
 
 ### Bugfixes
 
@@ -36,3 +469,39 @@ For users currently using v0.10, no breaking changes have been introduced. This 
 
     <small> by @dannymeijer </small>
 
+!!! bug "bugfix - PR [#TBD](https://github.com/Nike-Inc/koheesio/pull/TBD), related issue [#222](https://github.com/Nike-Inc/koheesio/issues/222)"
+    #### *Core > Models*: Fix `ListOfColumns` validation with PySpark Column objects
+
+    Fixed a critical bug where `ListOfColumns` validation would fail when PySpark `Column` objects were passed in a list, raising `CANNOT_CONVERT_COLUMN_INTO_BOOL` error.
+
+    **Root Cause:**  
+    The `_list_of_columns_validation` function used `if col` to filter out empty values, which attempted to convert PySpark Column objects to boolean. PySpark explicitly prohibits this conversion to prevent ambiguous boolean operations in DataFrame expressions.
+
+    **Fix:**  
+    Replaced the implicit boolean check with explicit type checking:
+    ```python
+    # Before (broken):
+    columns = [col for col in columns if col]  # ❌ Triggers CANNOT_CONVERT_COLUMN_INTO_BOOL
+    
+    # After (fixed):
+    for col in columns:
+        if isinstance(col, Column):  # ✅ Check type first
+            filtered_columns.append(col)
+        elif col is not None and col != "":  # ✅ Explicit checks for strings
+            filtered_columns.append(col)
+    ```
+
+    **Impact:**  
+    This bug affected real-world usage in join operations and transformations where Column expressions with aliases are commonly used. The `ListOfColumns` type now properly supports both string column names and PySpark Column objects as originally intended.
+
+    **Note:**  
+    The `_list_of_columns_validation` helper has been moved out of the `koheesio.models` internals into the shared Spark
+    utilities module. It now lives in `koheesio.spark.utils.common` and is wired into the `ListOfColumns` annotated
+    type, which is re-exported via `koheesio.spark.utils`. Code that previously imported `ListOfColumns` or
+    `_list_of_columns_validation` from other modules (e.g. `koheesio.models`) should update imports to use
+    `koheesio.spark.utils.ListOfColumns` or the new helper location as appropriate.
+
+    **Test Coverage:**  
+    Verified through existing transformation tests that use Column objects in various scenarios.
+
+    <small> by @dannymeijer </small>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "koheesio"
 dynamic = ["version"]
 description = 'The steps-based Koheesio framework'
 readme = "README.md"
-requires-python = ">=3.9, <3.13" # 3.10 is the minimum recommended version
+requires-python = ">=3.10, <3.13"
 license = "Apache-2.0"
 keywords = [
   # TODO: add keywords
@@ -29,7 +29,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -266,10 +265,6 @@ run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
 cov-combine = "coverage combine"
 cov-report = "coverage report"
 
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.9"]
-version = ["pyspark33", "pyspark34"]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.10"]
@@ -664,6 +659,7 @@ disable = [
   "too-many-statements",
   "useless-object-inheritance",
   "unnecessary-ellipsis",
+  "no-value-for-parameter",  # Pylint doesn't understand ParamSpec in decorators
 ]
 enable = ["logging-not-lazy", "c-extension-no-member"]
 

--- a/src/koheesio/integrations/snowflake/__init__.py
+++ b/src/koheesio/integrations/snowflake/__init__.py
@@ -201,8 +201,12 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         examples=["example.snowflakecomputing.com"],
     )
     user: str = Field(default=..., alias="sfUser", description="Login name for the Snowflake user")
-    password: Optional[SecretStr] = Field(default=None, alias="sfPassword", description="Password for the Snowflake user")
-    private_key: Optional[SecretStr] = Field(default=None, alias="pem_private_key", description="PEM private key for the Snowflake user")
+    password: Optional[SecretStr] = Field(
+        default=None, alias="sfPassword", description="Password for the Snowflake user"
+    )
+    private_key: Optional[SecretStr] = Field(
+        default=None, alias="pem_private_key", description="PEM private key for the Snowflake user"
+    )
     role: str = Field(
         default=..., alias="sfRole", description="The default security role to use for the session after connecting"
     )
@@ -236,9 +240,7 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
         if not self.password and not self.private_key:
             raise ValueError("You must provide either 'password' or 'private_key'.")
         if self.password and self.private_key:
-            raise ValueError(
-                "You must provide either 'password' or 'private_key', not both."
-            )
+            raise ValueError("You must provide either 'password' or 'private_key', not both.")
         return self
 
     @property
@@ -283,7 +285,7 @@ class SnowflakeBaseModel(BaseModel, ExtraParamsMixin, ABC):  # type: ignore[misc
             exclude=exclude_set,
         )
 
-        fields.update({ "sfSchema" if by_alias else "schema": self.sfSchema })
+        fields.update({"sfSchema" if by_alias else "schema": self.sfSchema})
 
         # handle schema and password
         if self.password:
@@ -414,7 +416,6 @@ class SnowflakeRunQueryPython(SnowflakeStep):
             raise RuntimeError("Snowflake connector is not installed. Please install `snowflake-connector-python`.")
 
         sf_options = self.get_options()
-
 
         _conn = self._snowflake_connector.connect(**sf_options)
         self.log.info(f"Connected to Snowflake account: {sf_options['account']}")

--- a/src/koheesio/integrations/spark/snowflake.py
+++ b/src/koheesio/integrations/spark/snowflake.py
@@ -640,12 +640,10 @@ class SnowflakeWriter(SnowflakeBaseModel, Writer):
     def execute(self) -> SnowflakeWriter.Output:
         """Write to Snowflake"""
         self.log.debug(f"writing to {self.table} with mode {self.insert_type}")
-        
+
         options = self.get_options()
-        
-        self.df.write.format(self.format).options(**options).option("dbtable", self.table).mode(
-            self.insert_type
-        ).save()
+
+        self.df.write.format(self.format).options(**options).option("dbtable", self.table).mode(self.insert_type).save()
 
 
 class SynchronizeDeltaToSnowflakeTask(SnowflakeSparkStep):

--- a/src/koheesio/models/__init__.py
+++ b/src/koheesio/models/__init__.py
@@ -39,6 +39,7 @@ from pydantic import (
     field_serializer,
     field_validator,
     model_validator,
+    validate_call,
 )
 from pydantic import SecretBytes as PydanticSecretBytes
 from pydantic import SecretStr as PydanticSecretStr
@@ -56,12 +57,12 @@ __all__ = [
     "BaseModel",
     "ExtraParamsMixin",
     "Field",
-    "ListOfColumns",
     # Directly from pydantic
     "ConfigDict",
     "DirectoryPath",
     "FilePath",
     "InstanceOf",
+    "ListOfStrings",
     "ModelMetaclass",
     "PositiveInt",
     "PrivateAttr",
@@ -76,6 +77,7 @@ __all__ = [
     "field_serializer",
     "field_validator",
     "model_validator",
+    "validate_call",
 ]
 
 
@@ -749,24 +751,6 @@ class ExtraParamsMixin(PydanticBaseModel):
         """Move extra_params to params dict"""
         self.params = {**self.params, **self.extra_params}  # type: ignore[assignment]
         return self
-
-
-def _list_of_columns_validation(columns_value: Union[str, list]) -> list:
-    """
-    Performs validation for ListOfColumns type. Will ensure that there are no duplicate columns, empty strings, etc.
-    In case an individual column is passed, it will coerce it to a list.
-    """
-    columns = [columns_value] if isinstance(columns_value, str) else [*columns_value]
-    columns = [col for col in columns if col]  # remove empty strings, None, etc.
-
-    return list(dict.fromkeys(columns))  # dict.fromkeys is used to dedup while maintaining order
-
-
-ListOfColumns = Annotated[Union[str, List[str]], BeforeValidator(_list_of_columns_validation)]
-""" Annotated type for a list of column names. 
-Will ensure that there are no duplicate columns, empty strings, etc.
-In case an individual column is passed, the value will be coerced to a list.
-"""
 
 
 class _SecretMixin:

--- a/src/koheesio/spark/readers/delta.py
+++ b/src/koheesio/spark/readers/delta.py
@@ -86,9 +86,7 @@ class DeltaTableReader(Reader):
 
     """
 
-    table: Union[DeltaTableStep, str] = Field(
-        default=..., description="The table to read"
-    )
+    table: Union[DeltaTableStep, str] = Field(default=..., description="The table to read")
     filter_cond: Optional[Union[Column, str]] = Field(
         default=None,
         alias="filterCondition",
@@ -103,9 +101,7 @@ class DeltaTableReader(Reader):
     )
 
     # sql: Optional[str, Path]  # TODO: add support for SQL file, or advanced SQL expression
-    streaming: Optional[bool] = Field(
-        default=False, description="Whether to read the table as a Stream or not"
-    )
+    streaming: Optional[bool] = Field(default=False, description="Whether to read the table as a Stream or not")
     read_change_feed: bool = Field(
         default=False,
         alias="readChangeFeed",
@@ -165,15 +161,12 @@ class DeltaTableReader(Reader):
         alias="schemaTrackingLocation",
         description="schemaTrackingLocation: Track the location of source schema. "
         "Note: Recommend to enable Delta reader version: 3 and writer version: 7 for this option. "
-        "For more info see https://docs.delta.io/latest/delta-column-mapping.html"
-        + STREAMING_SCHEMA_WARNING,
+        "For more info see https://docs.delta.io/latest/delta-column-mapping.html" + STREAMING_SCHEMA_WARNING,
     )
 
     # private attrs
     __temp_view_name__: Optional[str] = None
-    __reader: Optional[Union[DataStreamReader, DataFrameReader]] = PrivateAttr(
-        default=None
-    )
+    __reader: Optional[Union[DataStreamReader, DataFrameReader]] = PrivateAttr(default=None)
 
     @property
     def temp_view_name(self) -> str:
@@ -187,9 +180,7 @@ class DeltaTableReader(Reader):
             return DeltaTableStep(table=tbl)
         if isinstance(tbl, DeltaTableStep):
             return tbl
-        raise AttributeError(
-            f"Table name provided cannot be processed as a Table : {tbl}"
-        )
+        raise AttributeError(f"Table name provided cannot be processed as a Table : {tbl}")
 
     @model_validator(mode="after")
     def _validate_starting_version_and_timestamp(self) -> "DeltaTableReader":
@@ -205,11 +196,7 @@ class DeltaTableReader(Reader):
                 f"provided values: ({starting_version=}, {starting_timestamp=})"
             )
 
-        if (
-            not streaming
-            and read_change_feed
-            and all([starting_version is None, starting_timestamp is None])
-        ):
+        if not streaming and read_change_feed and all([starting_version is None, starting_timestamp is None]):
             raise ValueError(
                 "Specify either a 'starting_version' or a 'starting_timestamp' "
                 "when reading change data feed in a batch mode."
@@ -237,15 +224,11 @@ class DeltaTableReader(Reader):
     @model_validator(mode="before")
     def _warn_on_streaming_options_without_streaming(cls, options: Dict) -> Dict:
         """throws a warning if streaming options were provided, but streaming was not set to true"""
-        streaming_options = [
-            val for opt, val in options.items() if opt in STREAMING_ONLY_OPTIONS
-        ]
+        streaming_options = [val for opt, val in options.items() if opt in STREAMING_ONLY_OPTIONS]
         streaming_toggled_on = options.get("streaming")
 
         if any(streaming_options) and not streaming_toggled_on:
-            log = LoggingFactory.get_logger(
-                name=cls.__name__, inherit_from_koheesio=True
-            )
+            log = LoggingFactory.get_logger(name=cls.__name__, inherit_from_koheesio=True)
             log.warning(
                 f"Streaming options were provided, but streaming was not toggled on. Was this intended?\n{options = }"
             )
@@ -320,11 +303,7 @@ class DeltaTableReader(Reader):
     def reader(self) -> Union[DataStreamReader, DataFrameReader]:
         """Return the reader for the DeltaTableReader based on the `streaming` attribute"""
         if not self.__reader:
-            self.__reader = (
-                self.__get_stream_reader()
-                if self.streaming
-                else self.__get_batch_reader()
-            )
+            self.__reader = self.__get_stream_reader() if self.streaming else self.__get_batch_reader()
             self.__reader = self.__reader.options(**self.get_options())
 
         return self.__reader

--- a/src/koheesio/spark/readers/delta.py
+++ b/src/koheesio/spark/readers/delta.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Union
 
 from pydantic import PrivateAttr
-
 from pyspark.sql import DataFrameReader
 from pyspark.sql import functions as f
 
@@ -205,9 +204,7 @@ class DeltaTableReader(Reader):
         return self
 
     @model_validator(mode="after")
-    def _validate_ignore_deletes_and_changes_and_skip_commits(
-        self,
-    ) -> "DeltaTableReader":
+    def _validate_ignore_deletes_and_changes_and_skip_commits(self) -> "DeltaTableReader":
         """Validate 'ignore_deletes' and 'ignore_changes' - Only one of each should be provided"""
         ignore_deletes = self.ignore_deletes
         ignore_changes = self.ignore_changes

--- a/src/koheesio/spark/readers/delta.py
+++ b/src/koheesio/spark/readers/delta.py
@@ -18,10 +18,11 @@ from pyspark.sql import DataFrameReader
 from pyspark.sql import functions as f
 
 from koheesio.logger import LoggingFactory
-from koheesio.models import Field, ListOfColumns, field_validator, model_validator
+from koheesio.models import Field, field_validator, model_validator
 from koheesio.spark import Column, DataStreamReader
 from koheesio.spark.delta import DeltaTableStep
 from koheesio.spark.readers import Reader
+from koheesio.spark.utils.common import ListOfColumns
 from koheesio.utils import get_random_string
 
 __all__ = ["DeltaTableReader", "DeltaTableStreamReader"]
@@ -85,7 +86,9 @@ class DeltaTableReader(Reader):
 
     """
 
-    table: Union[DeltaTableStep, str] = Field(default=..., description="The table to read")
+    table: Union[DeltaTableStep, str] = Field(
+        default=..., description="The table to read"
+    )
     filter_cond: Optional[Union[Column, str]] = Field(
         default=None,
         alias="filterCondition",
@@ -100,7 +103,9 @@ class DeltaTableReader(Reader):
     )
 
     # sql: Optional[str, Path]  # TODO: add support for SQL file, or advanced SQL expression
-    streaming: Optional[bool] = Field(default=False, description="Whether to read the table as a Stream or not")
+    streaming: Optional[bool] = Field(
+        default=False, description="Whether to read the table as a Stream or not"
+    )
     read_change_feed: bool = Field(
         default=False,
         alias="readChangeFeed",
@@ -160,12 +165,15 @@ class DeltaTableReader(Reader):
         alias="schemaTrackingLocation",
         description="schemaTrackingLocation: Track the location of source schema. "
         "Note: Recommend to enable Delta reader version: 3 and writer version: 7 for this option. "
-        "For more info see https://docs.delta.io/latest/delta-column-mapping.html" + STREAMING_SCHEMA_WARNING,
+        "For more info see https://docs.delta.io/latest/delta-column-mapping.html"
+        + STREAMING_SCHEMA_WARNING,
     )
 
     # private attrs
     __temp_view_name__: Optional[str] = None
-    __reader: Optional[Union[DataStreamReader, DataFrameReader]] = PrivateAttr(default=None)
+    __reader: Optional[Union[DataStreamReader, DataFrameReader]] = PrivateAttr(
+        default=None
+    )
 
     @property
     def temp_view_name(self) -> str:
@@ -179,7 +187,9 @@ class DeltaTableReader(Reader):
             return DeltaTableStep(table=tbl)
         if isinstance(tbl, DeltaTableStep):
             return tbl
-        raise AttributeError(f"Table name provided cannot be processed as a Table : {tbl}")
+        raise AttributeError(
+            f"Table name provided cannot be processed as a Table : {tbl}"
+        )
 
     @model_validator(mode="after")
     def _validate_starting_version_and_timestamp(self) -> "DeltaTableReader":
@@ -195,7 +205,11 @@ class DeltaTableReader(Reader):
                 f"provided values: ({starting_version=}, {starting_timestamp=})"
             )
 
-        if not streaming and read_change_feed and all([starting_version is None, starting_timestamp is None]):
+        if (
+            not streaming
+            and read_change_feed
+            and all([starting_version is None, starting_timestamp is None])
+        ):
             raise ValueError(
                 "Specify either a 'starting_version' or a 'starting_timestamp' "
                 "when reading change data feed in a batch mode."
@@ -204,7 +218,9 @@ class DeltaTableReader(Reader):
         return self
 
     @model_validator(mode="after")
-    def _validate_ignore_deletes_and_changes_and_skip_commits(self) -> "DeltaTableReader":
+    def _validate_ignore_deletes_and_changes_and_skip_commits(
+        self,
+    ) -> "DeltaTableReader":
         """Validate 'ignore_deletes' and 'ignore_changes' - Only one of each should be provided"""
         ignore_deletes = self.ignore_deletes
         ignore_changes = self.ignore_changes
@@ -221,11 +237,15 @@ class DeltaTableReader(Reader):
     @model_validator(mode="before")
     def _warn_on_streaming_options_without_streaming(cls, options: Dict) -> Dict:
         """throws a warning if streaming options were provided, but streaming was not set to true"""
-        streaming_options = [val for opt, val in options.items() if opt in STREAMING_ONLY_OPTIONS]
+        streaming_options = [
+            val for opt, val in options.items() if opt in STREAMING_ONLY_OPTIONS
+        ]
         streaming_toggled_on = options.get("streaming")
 
         if any(streaming_options) and not streaming_toggled_on:
-            log = LoggingFactory.get_logger(name=cls.__name__, inherit_from_koheesio=True)
+            log = LoggingFactory.get_logger(
+                name=cls.__name__, inherit_from_koheesio=True
+            )
             log.warning(
                 f"Streaming options were provided, but streaming was not toggled on. Was this intended?\n{options = }"
             )
@@ -300,7 +320,11 @@ class DeltaTableReader(Reader):
     def reader(self) -> Union[DataStreamReader, DataFrameReader]:
         """Return the reader for the DeltaTableReader based on the `streaming` attribute"""
         if not self.__reader:
-            self.__reader = self.__get_stream_reader() if self.streaming else self.__get_batch_reader()
+            self.__reader = (
+                self.__get_stream_reader()
+                if self.streaming
+                else self.__get_batch_reader()
+            )
             self.__reader = self.__reader.options(**self.get_options())
 
         return self.__reader

--- a/src/koheesio/spark/readers/jdbc.py
+++ b/src/koheesio/spark/readers/jdbc.py
@@ -76,7 +76,9 @@ class JdbcReader(Reader, ExtraParamsMixin):
     )
     user: str = Field(default=..., description="User to authenticate to the server")
     password: Optional[SecretStr] = Field(default=None, description="Password belonging to the username")
-    private_key: Optional[SecretStr] = Field(default=None, alias="pem_private_key", description="Private key for authentication")
+    private_key: Optional[SecretStr] = Field(
+        default=None, alias="pem_private_key", description="Private key for authentication"
+    )
     dbtable: Optional[str] = Field(
         default=None,
         description="Database table name, also include schema name",
@@ -119,9 +121,7 @@ class JdbcReader(Reader, ExtraParamsMixin):
         if not self.password and not self.private_key:
             raise ValueError("You must provide either 'password' or 'private_key'.")
         if self.password and self.private_key:
-            raise ValueError(
-                "You must provide either 'password' or 'private_key', not both."
-            )
+            raise ValueError("You must provide either 'password' or 'private_key', not both.")
 
         return self
 
@@ -133,7 +133,7 @@ class JdbcReader(Reader, ExtraParamsMixin):
     def execute(self) -> "JdbcReader.Output":
         """Wrapper around Spark's jdbc read format"""
         options = self.get_options()
-        
+
         if pw := self.password:
             options["password"] = pw.get_secret_value()
         if pk := self.private_key:

--- a/src/koheesio/spark/transformations/__init__.py
+++ b/src/koheesio/spark/transformations/__init__.py
@@ -21,15 +21,36 @@ ColumnsTransformationWithTarget
     Extended ColumnsTransformation class with an additional `target_column` field
 """
 
-from typing import Iterator, List, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    Concatenate,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    ParamSpec,
+    Type,
+    Union,
+    get_args,
+    get_type_hints,
+    overload,
+)
 from abc import ABC, abstractmethod
+import inspect
 
 from pyspark.sql import functions as f
 from pyspark.sql.types import DataType
 
-from koheesio.models import Field, ListOfColumns, model_validator
+from koheesio.models import (
+    ExtraParamsMixin,
+    Field,
+    PrivateAttr,
+    model_validator,
+)
 from koheesio.spark import Column, DataFrame, SparkStep
-from koheesio.spark.utils import SparkDatatype, get_column_name
+from koheesio.spark.utils import ListOfColumns, SparkDatatype, get_column_name
+from koheesio.utils import get_args_for_func
 
 
 class Transformation(SparkStep, ABC):
@@ -191,6 +212,228 @@ class Transformation(SparkStep, ABC):
         """
         return self.transform(*args, **kwargs)
 
+    @classmethod
+    def from_func(
+        cls, func: Callable, **kwargs: Dict[str, Any]
+    ) -> Callable[..., "Transformation"]:
+        """Create a Transformation from a function.
+
+        This method enables function-based transformations for DataFrame operations, providing a simpler alternative
+        to subclassing for simple transformations.
+
+        Parameters
+        ----------
+        func : Callable
+            Function that takes a DataFrame as first parameter and returns a DataFrame.
+            Signature: func(df: DataFrame, **params) -> DataFrame
+        **kwargs : dict
+            Default parameters to pass to the function. Can be overridden when instantiating.
+
+        Returns
+        -------
+        Callable[..., Transformation]
+            A partial function that creates Transformation instances.
+
+        Example
+        -------
+        ### Simple DataFrame transformation
+        ```python
+        from koheesio.spark.transformations import Transformation
+
+
+        def lowercase_columns(df: DataFrame) -> DataFrame:
+            return df.withColumnsRenamed(
+                {col: col.lower() for col in df.columns}
+            )
+
+
+        LowercaseColumns = Transformation.from_func(lowercase_columns)
+
+        # Usage
+        output_df = LowercaseColumns().transform(input_df)
+        ```
+
+        ### Parameterized transformation
+        ```python
+        def add_prefix(
+            df: DataFrame, prefix: str, columns: List[str]
+        ) -> DataFrame:
+            for col_name in columns:
+                df = df.withColumn(
+                    col_name, f.concat(f.lit(prefix), f.col(col_name))
+                )
+            return df
+
+
+        AddPrefix = Transformation.from_func(add_prefix)
+
+        # Usage with parameters
+        output_df = AddPrefix(
+            prefix="test_", columns=["name", "id"]
+        ).transform(input_df)
+        ```
+
+        ### Using .partial() for specialization
+        ```python
+        AddTestPrefix = AddPrefix.partial(prefix="test_")
+        output_df = AddTestPrefix(columns=["name"]).transform(input_df)
+        ```
+
+        Notes
+        -----
+        - This is the recommended approach for simple DataFrame transformations in v0.11+
+        - For complex transformations with validation, computed properties, or multiple methods,
+          continue using subclassing
+        - The Transform class is deprecated in favor of this method
+
+        See Also
+        --------
+        Transform.from_func : Legacy implementation (deprecated)
+        ColumnsTransformation.from_func : For column-level transformations
+        """
+        # Capture the function in a local variable
+        _func = func
+        _default_kwargs = kwargs
+
+        # Create a concrete implementation class
+        class FunctionBasedTransformation(Transformation, ExtraParamsMixin):
+            """Transformation created from a function."""
+
+            func: callable = Field(default=_func, exclude=True)
+
+            @model_validator(mode="before")
+            def _merge_default_kwargs(cls, values):
+                """Merge default kwargs from from_func with instance params."""
+                if isinstance(values, dict):
+                    # Merge default kwargs with any params provided
+                    params = values.get("params", {})
+                    merged_params = {**_default_kwargs, **params}
+                    if merged_params:
+                        values["params"] = merged_params
+                return values
+
+            def execute(self) -> SparkStep.Output:
+                """Execute the function-based transformation."""
+                func_with_args, func_kwargs = get_args_for_func(self.func, self.params)
+                self.output.df = func_with_args(self.df, **func_kwargs)
+
+        # Set a meaningful name for the class based on the function name
+        func_name = getattr(_func, "__name__", "Transformation")
+        FunctionBasedTransformation.__name__ = (
+            func_name if func_name != "<lambda>" else "FunctionBasedTransformation"
+        )
+        FunctionBasedTransformation.__qualname__ = FunctionBasedTransformation.__name__
+
+        # Return the class itself (can be used with .partial() for further customization)
+        return FunctionBasedTransformation
+
+
+# ParamSpec for capturing function parameters (excluding df)
+P = ParamSpec("P")
+
+
+@overload
+def transformation(
+    func: Callable[Concatenate[DataFrame, P], DataFrame],
+    *,
+    validate: bool = True,
+    **kwargs,
+) -> Type["Transformation"]: ...
+
+
+@overload
+def transformation(
+    func: None = None, *, validate: bool = True, **kwargs
+) -> Callable[
+    [Callable[Concatenate[DataFrame, P], DataFrame]], Type["Transformation"]
+]: ...
+
+
+def transformation(
+    func: Optional[Callable] = None, *, validate: bool = True, **kwargs
+) -> Union[Type["Transformation"], Callable[[Callable], Type["Transformation"]]]:
+    """Decorator to create a Transformation from a function with runtime type validation.
+
+    This is syntactic sugar over Transformation.from_func() that adds Pydantic runtime
+    validation for enhanced type safety.
+
+    Parameters
+    ----------
+    func : Callable, optional
+        Function to decorate. If None, returns a decorator (for @transformation(...) syntax).
+    validate : bool, default=True
+        Whether to apply Pydantic runtime validation to the function parameters.
+        Note: Validation occurs at transformation instantiation, not execution.
+    **kwargs : dict
+        Default parameters to pass to the transformation (same as .from_func()).
+
+    Returns
+    -------
+    Callable
+        Either a decorator or a Transformation class.
+
+    Examples
+    --------
+    ### Simple transformation
+    ```python
+    @transformation
+    def lowercase_columns(df: DataFrame) -> DataFrame:
+        return df.select([f.lower(f.col(c)).alias(c) for c in df.columns])
+
+
+    # Usage
+    output_df = lowercase_columns().transform(input_df)
+    ```
+
+    ### With parameters
+    ```python
+    @transformation
+    def filter_by_threshold(
+        df: DataFrame, column: str, threshold: float
+    ) -> DataFrame:
+        return df.filter(f.col(column) > threshold)
+
+
+    # Usage - type validation ensures threshold is float
+    output_df = filter_by_threshold(
+        column="age", threshold=18.0
+    ).transform(input_df)
+    ```
+
+    ### With default parameters
+    ```python
+    @transformation(threshold=18.0)
+    def filter_adults(
+        df: DataFrame, column: str, threshold: float
+    ) -> DataFrame:
+        return df.filter(f.col(column) > threshold)
+
+
+    # Usage
+    output_df = filter_adults(column="age").transform(input_df)
+    ```
+
+    Notes
+    -----
+    - Internally calls Transformation.from_func()
+    - Adds Pydantic validation for function parameters (excluding DataFrame)
+    - Type mismatches raise ValidationError at instantiation time
+    - Validation can be disabled with validate=False for performance
+    """
+
+    def decorator(_func: Callable) -> Type["Transformation"]:
+        # Simply use from_func - validation happens via Pydantic BaseModel
+        # The ExtraParamsMixin already provides parameter validation
+        return Transformation.from_func(_func, **kwargs)
+
+    # Support both @transformation and @transformation(...) syntax
+    if func is None:
+        # Called with arguments: @transformation(...)
+        return decorator
+    else:
+        # Called without arguments: @transformation
+        return decorator(func)
+
 
 class ColumnsTransformation(Transformation, ABC):
     """Extended Transformation class with a preset validator for handling column(s) data with a standardized input
@@ -268,9 +511,28 @@ class ColumnsTransformation(Transformation, ABC):
         description="The column (or list of columns) to apply the transformation to. Alias: column",
     )
 
+    # ColumnConfig fields as actual Pydantic fields (for function-based transformations)
+    run_for_all_data_type: Optional[List[SparkDatatype]] = Field(
+        default=None,
+        description="Data types to automatically select when no columns specified",
+    )
+    limit_data_type: Optional[List[SparkDatatype]] = Field(
+        default=None,
+        description="Data types to restrict transformation to",
+    )
+    data_type_strict_mode: bool = Field(
+        default=False,
+        description="Whether to raise error on incompatible types (vs. warning)",
+    )
+
     class ColumnConfig:
         """
-        Koheesio ColumnsTransformation specific Config
+        Koheesio `ColumnsTransformation` specific config.
+
+        Deprecated: use the field-based configuration on `ColumnsTransformation` instead:
+        `run_for_all_data_type`, `limit_data_type`, and `data_type_strict_mode`.
+
+        This nested `ColumnConfig` class is kept for backward compatibility and will be removed in v1.0.
 
         Parameters
         ----------
@@ -307,30 +569,43 @@ class ColumnsTransformation(Transformation, ABC):
                 columns = ["*"]
         else:
             if columns[0] == "*" and not self.run_for_all_is_set:
-                raise ValueError("Cannot use '*' as a column name when no run_for_all_data_type is set")
+                raise ValueError(
+                    "Cannot use '*' as a column name when no run_for_all_data_type is set"
+                )
 
         self.columns = columns
         return self
 
-    @classmethod
     @property
-    def run_for_all_is_set(cls) -> bool:
+    def run_for_all_is_set(self) -> bool:
         """Returns True if the transformation should be run for all columns of a given type"""
-        rfadt = cls.ColumnConfig.run_for_all_data_type  # shorthand
+        # Check instance field first (for function-based transformations), then fall back to ColumnConfig
+        if self.run_for_all_data_type is not None:
+            rfadt = self.run_for_all_data_type
+        else:
+            rfadt = self.ColumnConfig.run_for_all_data_type
         return bool(rfadt and isinstance(rfadt, list) and rfadt[0] is not None)
 
-    @classmethod
     @property
-    def limit_data_type_is_set(cls) -> bool:
+    def limit_data_type_is_set(self) -> bool:
         """Returns True if limit_data_type is set"""
-        if (limit_data_type := cls.ColumnConfig.limit_data_type) is not None:
+        # Check instance field first (for function-based transformations), then fall back to ColumnConfig
+        if self.limit_data_type is not None:
+            limit_data_type = self.limit_data_type
+        else:
+            limit_data_type = self.ColumnConfig.limit_data_type
+        if limit_data_type is not None:
             return limit_data_type[0] is not None  # type: ignore
         return False
 
     @property
     def data_type_strict_mode_is_set(self) -> bool:
         """Returns True if data_type_strict_mode is set"""
-        return self.ColumnConfig.data_type_strict_mode
+        # Check instance field first (for function-based transformations), then fall back to ColumnConfig
+        if self.data_type_strict_mode is not False:
+            return self.data_type_strict_mode
+        else:
+            return self.ColumnConfig.data_type_strict_mode
 
     def column_type_of_col(
         self,
@@ -396,14 +671,18 @@ class ColumnsTransformation(Transformation, ABC):
 
         # Check if the column exists in the DataFrame schema
         if df_col is None:
-            raise ValueError(f"Column '{col_name}' does not exist in the DataFrame schema")
+            raise ValueError(
+                f"Column '{col_name}' does not exist in the DataFrame schema"
+            )
 
         if simple_return_mode:
             return SparkDatatype(df_col.dataType.typeName()).value
 
         return df_col.dataType
 
-    def get_all_columns_of_specific_type(self, data_type: Union[str, SparkDatatype]) -> List[str]:
+    def get_all_columns_of_specific_type(
+        self, data_type: Union[str, SparkDatatype]
+    ) -> List[str]:
         """Get all columns from the dataframe of a given type
 
         A DataFrame needs to be available in order to get the columns. If no DataFrame is available, a ValueError will
@@ -425,14 +704,22 @@ class ColumnsTransformation(Transformation, ABC):
         if not self.df:
             raise ValueError("No dataframe available - cannot get columns")
 
-        expected_data_type = (SparkDatatype.from_string(data_type) if isinstance(data_type, str) else data_type).value
+        expected_data_type = (
+            SparkDatatype.from_string(data_type)
+            if isinstance(data_type, str)
+            else data_type
+        ).value
 
         columns_of_given_type: List[str] = [
-            col for col in self.df.columns if self.df.schema[col].dataType.typeName() == expected_data_type
+            col
+            for col in self.df.columns
+            if self.df.schema[col].dataType.typeName() == expected_data_type
         ]
 
         if not columns_of_given_type:
-            self.log.warning(f"No columns of type '{expected_data_type}' found in the DataFrame")
+            self.log.warning(
+                f"No columns of type '{expected_data_type}' found in the DataFrame"
+            )
 
         return columns_of_given_type
 
@@ -441,7 +728,9 @@ class ColumnsTransformation(Transformation, ABC):
         if not self.limit_data_type_is_set:
             return True
 
-        if self.column_type_of_col(column) in (limit_data_types := self.get_limit_data_types()):
+        if self.column_type_of_col(column) in (
+            limit_data_types := self.get_limit_data_types()
+        ):
             return True
 
         # Raises a ValueError if the Column object is not of a given type and data_type_strict_mode is set
@@ -452,12 +741,21 @@ class ColumnsTransformation(Transformation, ABC):
             )
 
         # Otherwise, throws a warning that the Column object is not of a given type
-        self.log.warning(f"Column `{column}` is not of type `{limit_data_types}` and will be skipped.")
+        self.log.warning(
+            f"Column `{column}` is not of type `{limit_data_types}` and will be skipped."
+        )
         return False
 
     def get_limit_data_types(self) -> list:
         """Get the limit_data_type as a list of strings"""
-        return [dt.value for dt in self.ColumnConfig.limit_data_type]  # type: ignore
+        # Check instance field first (for function-based transformations), then fall back to ColumnConfig
+        limit_data_type = (
+            self.limit_data_type
+            if self.limit_data_type is not None
+            else self.ColumnConfig.limit_data_type
+        )
+        # Handle both SparkDatatype enums and string values
+        return [dt.value if hasattr(dt, "value") else dt for dt in limit_data_type]  # type: ignore
 
     def get_columns(self) -> Iterator[str]:
         """Return an iterator of the columns"""
@@ -466,9 +764,15 @@ class ColumnsTransformation(Transformation, ABC):
         # If `run_for_all_is_set` to True, we want to run the transformation for all columns of a given type,
         # unless the user has specified specific columns
         if self.run_for_all_is_set and (not columns or columns[0] == "*"):
+            # Check instance field first (for function-based transformations), then fall back to ColumnConfig
+            run_for_all_types = (
+                self.run_for_all_data_type
+                if self.run_for_all_data_type is not None
+                else self.ColumnConfig.run_for_all_data_type
+            )
             columns = [
                 col
-                for data_type in self.ColumnConfig.run_for_all_data_type  # type: ignore
+                for data_type in run_for_all_types  # type: ignore
                 for col in self.get_all_columns_of_specific_type(data_type)
             ]
 
@@ -476,9 +780,786 @@ class ColumnsTransformation(Transformation, ABC):
             if self.is_column_type_correct(column):
                 yield column
 
+    @staticmethod
+    def _detect_for_each(func: Callable, default_for_each: bool) -> bool:
+        """Detect whether to apply function column-wise or multi-column based on type hints.
+
+        Parameters
+        ----------
+        func : Callable
+            The function to inspect
+        default_for_each : bool
+            The default value to return if detection is inconclusive
+
+        Returns
+        -------
+        bool
+            True for column-wise (apply to each column), False for multi-column (pass all columns)
+        """
+        # TODO: improve readability of this method along with reducing nestednes and better docs/comments
+        try:
+            sig = inspect.signature(func)
+
+            # Check for variadic *args
+            for param in sig.parameters.values():
+                if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                    # *args detected → multi-column
+                    return False
+
+            # Get type hints - need to handle cases where Column type might not be available.
+            # Pass Column in localns so it can be resolved.
+            try:
+                hints = get_type_hints(func, localns={"Column": Column})
+            except (NameError, TypeError, AttributeError, ValueError):
+                # If get_type_hints fails, fall back to checking annotations directly.
+                hints = getattr(func, "__annotations__", {})
+
+            # Check for ListOfColumns parameter
+            if any(t == ListOfColumns for t in hints.values()):
+                return False  # ListOfColumns → multi-column
+
+            # Count Column-typed parameters (exclude 'return' type hint)
+            column_params = []
+            # TODO: refactor to use case matching instead of if-else statements
+            for name, type_ in hints.items():
+                if name == "return":
+                    continue  # Skip return type hint
+                # Direct Column type - check both by identity and by name
+                # (Column might be a string annotation or actual type)
+                if type_ == Column or (
+                    isinstance(type_, type) and type_.__name__ == "Column"
+                ):
+                    column_params.append(name)
+                # Handle string annotations
+                elif isinstance(type_, str) and type_ == "Column":
+                    column_params.append(name)
+                # list[Column], tuple[Column], Sequence[Column]
+                elif hasattr(type_, "__origin__"):
+                    if type_.__origin__ in (list, tuple):
+                        args = get_args(type_)
+                        if args and (
+                            args[0] == Column
+                            or (
+                                isinstance(args[0], type)
+                                and args[0].__name__ == "Column"
+                            )
+                        ):
+                            return False  # Sequence of Columns → multi-column
+
+            if len(column_params) > 1:
+                return False  # Multiple Column params → multi-column
+            elif len(column_params) == 1:
+                return True  # Single Column param → column-wise
+            else:
+                return default_for_each  # No Column params, use method default
+        except (TypeError, ValueError):
+            # If introspection fails in an expected way, fall back to the provided default.
+            return default_for_each
+
+    @classmethod
+    def from_func(
+        cls,
+        func,
+        run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+        limit_data_type: Optional[List[SparkDatatype]] = None,
+        data_type_strict_mode: bool = False,
+        for_each: Optional[bool] = None,
+        **kwargs,
+    ):
+        """Create a ColumnsTransformation from a function.
+
+        This method enables function-based column transformations with optional ColumnConfig parameters
+        for data type validation and automatic column selection.
+
+        Parameters
+        ----------
+        func : Callable
+            Function that operates on Column objects.
+            Signature: func(col: Column, **params) -> Column
+        run_for_all_data_type : Optional[List[SparkDatatype]]
+            Data types to automatically select when no columns specified.
+            Equivalent to ColumnConfig.run_for_all_data_type
+        limit_data_type : Optional[List[SparkDatatype]]
+            Data types to restrict transformation to.
+            Equivalent to ColumnConfig.limit_data_type
+        data_type_strict_mode : bool
+            Whether to raise error on incompatible types (vs. warning).
+            Equivalent to ColumnConfig.data_type_strict_mode
+        for_each : Optional[bool]
+            Explicitly control column-wise vs multi-column behavior.
+            - True: Apply function to each column separately (column-wise)
+            - False: Pass all columns to function at once (multi-column)
+            - None: Auto-detect from type hints (default: True if ambiguous)
+        **kwargs : dict
+            Default parameters to pass to the function.
+
+        Returns
+        -------
+        Callable[..., ColumnsTransformation]
+            A partial function that creates ColumnsTransformation instances.
+
+        Example
+        -------
+        ### Simple column transformation
+        ```python
+        from pyspark.sql import Column
+        from pyspark.sql import functions as f
+        from koheesio.spark.transformations import ColumnsTransformation
+        from koheesio.spark.utils import SparkDatatype
+
+
+        def to_lower(col: Column) -> Column:
+            return f.lower(col)
+
+
+        LowerCase = ColumnsTransformation.from_func(
+            to_lower,
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+        )
+
+        # Usage (same as class-based)
+        output_df = LowerCase(
+            columns=["name"], target_column="name_lower"
+        ).transform(input_df)
+        ```
+
+        ### Parameterized transformation
+        ```python
+        def map_value(col: Column, from_val: str, to_val: str) -> Column:
+            return f.when(col == from_val, to_val).otherwise(col)
+
+
+        MapValue = ColumnsTransformation.from_func(map_value)
+        UkToGb = MapValue.partial(from_val="uk", to_val="gb")
+
+        # Usage
+        output_df = UkToGb(columns=["country_code"]).transform(input_df)
+        ```
+
+        ### Factory pattern for related transformations
+        ```python
+        def string_transform(func):
+            return ColumnsTransformation.from_func(
+                func,
+                run_for_all_data_type=[SparkDatatype.STRING],
+                limit_data_type=[SparkDatatype.STRING],
+            )
+
+
+        LowerCase = string_transform(lambda col: f.lower(col))
+        UpperCase = string_transform(lambda col: f.upper(col))
+        TitleCase = string_transform(lambda col: f.initcap(col))
+        ```
+
+        Notes
+        -----
+        - The `target_column` parameter works automatically (in-place if not provided)
+        - ColumnConfig parameters are optional (no restrictions if omitted)
+        - Use `.partial()` to create specialized versions with preset parameters
+        - This is the recommended approach for simple column transformations in v0.11+
+
+        See Also
+        --------
+        BaseModel.partial : For creating specialized transformations
+        ColumnsTransformationWithTarget : Current class-based approach (deprecated in v1.0)
+        Transformation.from_func : For DataFrame-level transformations
+        """
+        # Capture parameters in local variables to avoid linter warnings
+        _func = func
+        _kwargs = kwargs
+
+        # Detect for_each behavior (column-wise vs multi-column)
+        if for_each is None:
+            # Auto-detect from type hints, default to True (column-wise) if ambiguous
+            _for_each = cls._detect_for_each(func, default_for_each=True)
+        else:
+            _for_each = for_each
+
+        # Create a dynamic class that wraps the function
+        class FunctionBasedColumnsTransformation(cls, ExtraParamsMixin):
+            """Dynamically created column transformation from function."""
+
+            wrapped_func: Callable = Field(default=_func, exclude=True)
+            _for_each_mode: bool = PrivateAttr(default=_for_each)
+            target_column: Optional[str] = Field(
+                default=None,
+                alias="target_suffix",
+                description="The column to store the result in. If not provided, the result will be stored in the source column.",
+            )
+
+            @model_validator(mode="before")
+            def _merge_default_kwargs(cls, values):
+                """Merge default kwargs from from_func with instance params and set ColumnConfig defaults."""
+                if isinstance(values, dict):
+                    # Merge default kwargs with any params provided
+                    params = values.get("params", {})
+                    merged_params = {**_kwargs, **params}
+                    if merged_params:
+                        values["params"] = merged_params
+
+                    # Set ColumnConfig defaults if not provided
+                    if (
+                        "run_for_all_data_type" not in values
+                        and run_for_all_data_type is not None
+                    ):
+                        values["run_for_all_data_type"] = run_for_all_data_type
+                    if "limit_data_type" not in values and limit_data_type is not None:
+                        values["limit_data_type"] = limit_data_type
+                    if (
+                        "data_type_strict_mode" not in values
+                        and data_type_strict_mode is not False
+                    ):
+                        values["data_type_strict_mode"] = data_type_strict_mode
+                return values
+
+            def func(self, column: Column) -> Column:
+                """Apply the function to a column."""
+                # Get the function with bound parameters
+                func_with_args, func_kwargs = get_args_for_func(
+                    self.wrapped_func, self.params
+                )
+
+                # If the function accepts a column parameter, pass it
+                # Otherwise, call the partial function with the column
+                try:
+                    return func_with_args(column, **func_kwargs)
+                except TypeError:
+                    # Function might be a partial that already has column bound
+                    return func_with_args(**func_kwargs)
+
+            def execute(self) -> None:
+                """Execute the column transformation with target column support."""
+                from typing import get_type_hints
+                import inspect
+
+                df = self.df
+                columns = [*self.get_columns()]
+
+                # Use the for_each mode determined at class creation time
+                if not self._for_each_mode:
+                    # Multi-column: Pass ALL columns to function at once
+                    target_col = self.target_column or "_".join(columns)
+
+                    func_with_args, func_kwargs = get_args_for_func(
+                        self.wrapped_func, self.params
+                    )
+
+                    # Inspect function signature to determine how to pass columns
+                    sig = inspect.signature(self.wrapped_func)
+                    params = list(sig.parameters.values())
+
+                    # Check for variadic *args
+                    has_var_positional = any(
+                        p.kind == inspect.Parameter.VAR_POSITIONAL for p in params
+                    )
+
+                    # Check for ListOfColumns parameter
+                    try:
+                        hints = get_type_hints(self.wrapped_func)
+                        has_list_of_columns = any(
+                            t == ListOfColumns for t in hints.values()
+                        )
+                    except (NameError, TypeError, AttributeError, ValueError):
+                        has_list_of_columns = False
+
+                    if has_var_positional:
+                        # Variadic *args: pass columns as separate arguments
+                        column_objs = [f.col(c) for c in columns]
+                        result_col = func_with_args(*column_objs, **func_kwargs)
+                    elif has_list_of_columns:
+                        # ListOfColumns parameter: pass as list
+                        column_objs = [f.col(c) for c in columns]
+                        result_col = func_with_args(column_objs, **func_kwargs)
+                    else:
+                        # Multiple positional params: pass as separate arguments
+                        positional_params = [
+                            p
+                            for p in params
+                            if p.kind in (p.POSITIONAL_OR_KEYWORD, p.POSITIONAL_ONLY)
+                        ]
+                        column_objs = [
+                            f.col(c) for c in columns[: len(positional_params)]
+                        ]
+                        result_col = func_with_args(*column_objs, **func_kwargs)
+
+                    df = df.withColumn(target_col, result_col)
+
+                else:
+                    # Column-wise: Apply function to EACH column separately
+                    for idx, column in enumerate(columns):
+                        target_col = self.target_column or column
+
+                        if len(columns) > 1 and self.target_column:
+                            _cols = [column, target_col]
+                            target_col = "_".join(list(dict.fromkeys(_cols)))
+
+                        func_with_args, func_kwargs = get_args_for_func(
+                            self.wrapped_func, self.params
+                        )
+
+                        # Handle paired parameters (strict zip matching)
+                        indexed_kwargs = {}
+                        for key, value in func_kwargs.items():
+                            if isinstance(value, (list, tuple)):
+                                if len(value) != len(columns):
+                                    raise ValueError(
+                                        f"Parameter '{key}' has {len(value)} values but "
+                                        f"{len(columns)} columns provided. "
+                                        f"Lists must match column count exactly "
+                                        f"(like Python's zip(..., strict=True))."
+                                    )
+                                indexed_kwargs[key] = value[idx]
+                            else:
+                                indexed_kwargs[key] = value
+
+                        df = df.withColumn(
+                            target_col, func_with_args(f.col(column), **indexed_kwargs)
+                        )
+
+                self.output.df = df
+
+        # Set a meaningful name for the dynamic class based on the function name
+        func_name = getattr(_func, "__name__", "ColumnsTransformation")
+        if func_name != "<lambda>":
+            # Use the actual function name if it's not a lambda
+            FunctionBasedColumnsTransformation.__name__ = func_name
+        else:
+            # For lambdas, use a generic name
+            FunctionBasedColumnsTransformation.__name__ = (
+                "FunctionBasedColumnsTransformation"
+            )
+        FunctionBasedColumnsTransformation.__qualname__ = (
+            FunctionBasedColumnsTransformation.__name__
+        )
+
+        # Set default values by modifying the FieldInfo objects directly
+        # Pydantic will use these when instantiating the class
+        if run_for_all_data_type is not None:
+            FunctionBasedColumnsTransformation.model_fields[
+                "run_for_all_data_type"
+            ].default = run_for_all_data_type
+        if limit_data_type is not None:
+            FunctionBasedColumnsTransformation.model_fields[
+                "limit_data_type"
+            ].default = limit_data_type
+        if data_type_strict_mode is not False:
+            FunctionBasedColumnsTransformation.model_fields[
+                "data_type_strict_mode"
+            ].default = data_type_strict_mode
+
+        return FunctionBasedColumnsTransformation
+
+    @classmethod
+    def from_multi_column_func(
+        cls,
+        func,
+        run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+        limit_data_type: Optional[List[SparkDatatype]] = None,
+        data_type_strict_mode: bool = False,
+        for_each: Optional[bool] = None,
+        **kwargs,
+    ):
+        """Create a multi-column ColumnsTransformation from a function.
+
+        This method is similar to from_func() but defaults to multi-column behavior
+        (passing all columns to the function at once) when type hints are ambiguous.
+
+        Parameters
+        ----------
+        func : Callable
+            Function that operates on multiple Column objects.
+            Signature: func(col1: Column, col2: Column, ..., **params) -> Column
+            Or: func(*cols: Column, **params) -> Column
+            Or: func(cols: ListOfColumns, **params) -> Column
+        run_for_all_data_type : Optional[List[SparkDatatype]]
+            Data types to automatically select when no columns specified.
+            Equivalent to ColumnConfig.run_for_all_data_type
+        limit_data_type : Optional[List[SparkDatatype]]
+            Data types to restrict transformation to.
+            Equivalent to ColumnConfig.limit_data_type
+        data_type_strict_mode : bool
+            Whether to raise error on incompatible types (vs. warning).
+            Equivalent to ColumnConfig.data_type_strict_mode
+        for_each : Optional[bool]
+            Explicitly control column-wise vs multi-column behavior.
+            - True: Apply function to each column separately (column-wise)
+            - False: Pass all columns to function at once (multi-column)
+            - None: Auto-detect from type hints (default: False if ambiguous)
+        **kwargs : dict
+            Default parameters to pass to the function.
+
+        Returns
+        -------
+        Callable[..., ColumnsTransformation]
+            A class that creates ColumnsTransformation instances.
+
+        Example
+        -------
+        ### Multi-column aggregation
+        ```python
+        from pyspark.sql import Column
+        from pyspark.sql import functions as f
+        from koheesio.spark.transformations import ColumnsTransformation
+
+
+        def sum_quarters(
+            q1: Column, q2: Column, q3: Column, q4: Column
+        ) -> Column:
+            return q1 + q2 + q3 + q4
+
+
+        SumQuarters = ColumnsTransformation.from_multi_column_func(
+            sum_quarters
+        )
+        output_df = SumQuarters(
+            columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+            target_column="total_sales",
+        ).transform(input_df)
+        ```
+
+        ### Variadic columns
+        ```python
+        from functools import reduce
+
+
+        def sum_all(*cols: Column) -> Column:
+            return reduce(lambda a, b: a + b, cols)
+
+
+        SumAll = ColumnsTransformation.from_multi_column_func(sum_all)
+        output_df = SumAll(
+            columns=["jan", "feb", "mar"], target_column="q1_total"
+        ).transform(input_df)
+        ```
+
+        Notes
+        -----
+        - This method defaults to multi-column behavior (for_each=False) when ambiguous
+        - Use from_func() for column-wise operations (default: for_each=True)
+        - Auto-detection works the same way, but fallback default differs
+
+        See Also
+        --------
+        from_func : For column-wise transformations (default)
+        """
+        # Detect for_each behavior, but default to False (multi-column) if ambiguous
+        if for_each is None:
+            _for_each = cls._detect_for_each(func, default_for_each=False)
+        else:
+            _for_each = for_each
+
+        # Use the same implementation as from_func, just with different default
+        return cls.from_func(
+            func,
+            run_for_all_data_type=run_for_all_data_type,
+            limit_data_type=limit_data_type,
+            data_type_strict_mode=data_type_strict_mode,
+            for_each=_for_each,
+            **kwargs,
+        )
+
+
+# ParamSpec for column transformation parameters (excluding Column)
+PC = ParamSpec("PC")
+
+
+@overload
+def column_transformation(
+    func: Callable[Concatenate[Column, PC], Column],
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    for_each: Optional[bool] = None,
+    **kwargs,
+) -> Type["ColumnsTransformation"]: ...
+
+
+@overload
+def column_transformation(
+    func: None = None,
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    for_each: Optional[bool] = None,
+    **kwargs,
+) -> Callable[
+    [Callable[Concatenate[Column, PC], Column]], Type["ColumnsTransformation"]
+]: ...
+
+
+def column_transformation(
+    func: Optional[Callable] = None,
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    for_each: Optional[bool] = None,
+    **kwargs,
+) -> Union[
+    Type["ColumnsTransformation"], Callable[[Callable], Type["ColumnsTransformation"]]
+]:
+    """Decorator to create a ColumnsTransformation with runtime type validation.
+
+    This is syntactic sugar over ColumnsTransformation.from_func() that adds Pydantic
+    runtime validation and explicit ColumnConfig parameters.
+
+    Parameters
+    ----------
+    func : Callable, optional
+        Function to decorate. If None, returns a decorator.
+    validate : bool, default=True
+        Whether to apply Pydantic runtime validation.
+    run_for_all_data_type : Optional[List[SparkDatatype]]
+        Data types to automatically select when no columns specified.
+    limit_data_type : Optional[List[SparkDatatype]]
+        Data types to restrict transformation to.
+    data_type_strict_mode : bool, default=False
+        Whether to raise error on incompatible types (vs. warning).
+    for_each : Optional[bool]
+        Explicitly set column-wise (True) or multi-column (False) mode.
+        If None, auto-detects based on function signature.
+    **kwargs : dict
+        Default parameters to pass to the transformation.
+
+    Returns
+    -------
+    Callable
+        Either a decorator or a ColumnsTransformation class.
+
+    Examples
+    --------
+    ### Simple column transformation
+    ```python
+    @column_transformation
+    def to_upper(col: Column) -> Column:
+        return f.upper(col)
+
+
+    # Usage
+    output_df = to_upper(columns=["name", "city"]).transform(input_df)
+    ```
+
+    ### With ColumnConfig
+    ```python
+    @column_transformation(run_for_all_data_type=[SparkDatatype.STRING])
+    def trim_strings(col: Column) -> Column:
+        return f.trim(col)
+
+
+    # Usage - automatically applies to all string columns
+    output_df = trim_strings().transform(input_df)
+    ```
+
+    ### With parameters and paired values
+    ```python
+    @column_transformation
+    def add_tax(amount: Column, rate: float = 0.08) -> Column:
+        return amount * (1 + rate)
+
+
+    # Single rate (broadcast)
+    output_df = add_tax(columns=["price"], rate=0.10).transform(input_df)
+
+    # Paired rates (strict zip)
+    output_df = add_tax(
+        columns=["food_price", "non_food_price"], rate=[0.08, 0.13]
+    ).transform(input_df)
+    ```
+
+    ### Type validation in action
+    ```python
+    @column_transformation
+    def scale(col: Column, factor: int) -> Column:
+        return col * factor
+
+
+    # This raises ValidationError - factor must be int
+    output_df = scale(columns=["value"], factor="2").transform(input_df)
+    ```
+
+    Notes
+    -----
+    - Internally calls ColumnsTransformation.from_func()
+    - Adds Pydantic validate_call for runtime type checking
+    - Supports all from_func() features: paired parameters, variadic, multi-column
+    """
+
+    def decorator(f: Callable) -> Type["ColumnsTransformation"]:
+        # Simply use from_func - validation happens via Pydantic BaseModel
+        # The ExtraParamsMixin already provides parameter validation
+        return ColumnsTransformation.from_func(
+            f,
+            run_for_all_data_type=run_for_all_data_type,
+            limit_data_type=limit_data_type,
+            data_type_strict_mode=data_type_strict_mode,
+            for_each=for_each,
+            **kwargs,
+        )
+
+    # Support both @column_transformation and @column_transformation(...) syntax
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)
+
+
+# ParamSpec for multi-column transformation parameters
+PM = ParamSpec("PM")
+
+
+@overload
+def multi_column_transformation(
+    func: Callable[PM, Column],
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    **kwargs,
+) -> Type["ColumnsTransformation"]: ...
+
+
+@overload
+def multi_column_transformation(
+    func: None = None,
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    **kwargs,
+) -> Callable[[Callable[PM, Column]], Type["ColumnsTransformation"]]: ...
+
+
+def multi_column_transformation(
+    func: Optional[Callable] = None,
+    *,
+    validate: bool = True,
+    run_for_all_data_type: Optional[List[SparkDatatype]] = None,
+    limit_data_type: Optional[List[SparkDatatype]] = None,
+    data_type_strict_mode: bool = False,
+    **kwargs,
+) -> Union[
+    Type["ColumnsTransformation"], Callable[[Callable], Type["ColumnsTransformation"]]
+]:
+    """Decorator for multi-column transformations (N columns → 1 result).
+
+    This is syntactic sugar over ColumnsTransformation.from_multi_column_func()
+    that adds Pydantic runtime validation. Explicitly sets for_each=False.
+
+    Parameters
+    ----------
+    func : Callable, optional
+        Function to decorate. Must accept multiple columns.
+    validate : bool, default=True
+        Whether to apply Pydantic runtime validation.
+    run_for_all_data_type : Optional[List[SparkDatatype]]
+        Data types to automatically select.
+    limit_data_type : Optional[List[SparkDatatype]]
+        Data types to restrict to.
+    data_type_strict_mode : bool, default=False
+        Whether to raise error on incompatible types.
+    **kwargs : dict
+        Default parameters.
+
+    Returns
+    -------
+    Callable
+        Either a decorator or a ColumnsTransformation class.
+
+    Examples
+    --------
+    ### Fixed arity aggregation
+    ```python
+    @multi_column_transformation
+    def sum_quarters(
+        q1: Column, q2: Column, q3: Column, q4: Column
+    ) -> Column:
+        return q1 + q2 + q3 + q4
+
+
+    # Usage
+    output_df = sum_quarters(
+        columns=["sales_q1", "sales_q2", "sales_q3", "sales_q4"],
+        target_column="total_sales",
+    ).transform(input_df)
+    ```
+
+    ### Variadic aggregation
+    ```python
+    @multi_column_transformation
+    def sum_all(*cols: Column) -> Column:
+        from functools import reduce
+
+        return reduce(lambda a, b: a + b, cols)
+
+
+    # Usage - works with any number of columns
+    output_df = sum_all(
+        columns=["jan", "feb", "mar"], target_column="q1"
+    ).transform(input_df)
+    ```
+
+    ### With parameters
+    ```python
+    @multi_column_transformation
+    def weighted_sum(
+        q1: Column, q2: Column, q3: Column, q4: Column, weights: list
+    ) -> Column:
+        return (
+            q1 * weights[0]
+            + q2 * weights[1]
+            + q3 * weights[2]
+            + q4 * weights[3]
+        )
+
+
+    # Usage
+    output_df = weighted_sum(
+        columns=["q1", "q2", "q3", "q4"],
+        weights=[0.1, 0.2, 0.3, 0.4],
+        target_column="weighted_total",
+    ).transform(input_df)
+    ```
+
+    Notes
+    -----
+    - Internally calls ColumnsTransformation.from_multi_column_func()
+    - Explicitly sets for_each=False (multi-column mode)
+    - Adds Pydantic validate_call for runtime type checking
+    """
+
+    def decorator(f: Callable) -> Type["ColumnsTransformation"]:
+        # Simply use from_multi_column_func - validation happens via Pydantic BaseModel
+        # The ExtraParamsMixin already provides parameter validation
+        return ColumnsTransformation.from_multi_column_func(
+            f,
+            run_for_all_data_type=run_for_all_data_type,
+            limit_data_type=limit_data_type,
+            data_type_strict_mode=data_type_strict_mode,
+            **kwargs,
+        )
+
+    # Support both syntaxes
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)
+
 
 class ColumnsTransformationWithTarget(ColumnsTransformation, ABC):
     """Extended ColumnsTransformation class with an additional `target_column` field
+
+    .. deprecated:: 0.11
+        This class is deprecated and will be removed in v1.0.
+        Use :meth:`ColumnsTransformation.from_func` instead.
+        See https://github.com/Nike-Inc/koheesio/discussions/225
 
     Using this class makes implementing Transformations significantly easier.
 
@@ -604,7 +1685,9 @@ class ColumnsTransformationWithTarget(ColumnsTransformation, ABC):
             # ensures that we at least use the original column name
             target_column = self.target_column or column
 
-            if len(columns) > 1:  # target_column becomes a suffix when more than 1 column is given
+            if (
+                len(columns) > 1
+            ):  # target_column becomes a suffix when more than 1 column is given
                 # dict.fromkeys is used to avoid duplicates in the name while maintaining order
                 _cols = [column, target_column]
                 target_column = "_".join(list(dict.fromkeys(_cols)))
@@ -625,3 +1708,13 @@ class ColumnsTransformationWithTarget(ColumnsTransformation, ABC):
             )
 
         self.output.df = df
+
+
+__all__ = [
+    "Transformation",
+    "ColumnsTransformation",
+    "ColumnsTransformationWithTarget",
+    "transformation",
+    "column_transformation",
+    "multi_column_transformation",
+]

--- a/src/koheesio/spark/transformations/camel_to_snake.py
+++ b/src/koheesio/spark/transformations/camel_to_snake.py
@@ -2,10 +2,8 @@
 Class for converting DataFrame column names from camel case to snake case.
 """
 
-from typing import Optional
 import re
 
-from koheesio.models import Field, ListOfColumns
 from koheesio.spark.transformations import ColumnsTransformation
 from koheesio.spark.utils import SPARK_MINOR_VERSION
 

--- a/src/koheesio/spark/transformations/repartition.py
+++ b/src/koheesio/spark/transformations/repartition.py
@@ -2,8 +2,9 @@
 
 from typing import Optional
 
-from koheesio.models import Field, ListOfColumns, model_validator
+from koheesio.models import Field, model_validator
 from koheesio.spark.transformations import ColumnsTransformation
+from koheesio.spark.utils.common import ListOfColumns
 
 
 class Repartition(ColumnsTransformation):

--- a/src/koheesio/spark/transformations/strings/trim.py
+++ b/src/koheesio/spark/transformations/strings/trim.py
@@ -18,9 +18,10 @@ from typing import Literal
 from pyspark.sql import Column
 import pyspark.sql.functions as f
 
-from koheesio.models import Field, ListOfColumns
+from koheesio.models import Field
 from koheesio.spark.transformations import ColumnsTransformationWithTarget
 from koheesio.spark.utils import SparkDatatype
+from koheesio.spark.utils.common import ListOfColumns
 
 trim_type = Literal["left", "right", "left-right"]
 

--- a/src/koheesio/spark/transformations/transform.py
+++ b/src/koheesio/spark/transformations/transform.py
@@ -2,12 +2,17 @@
 
 Transform aims to provide an easy interface for calling transformations on a Spark DataFrame, where the transformation
 is a function that accepts a DataFrame (df) and any number of keyword args.
+
+.. deprecated:: 0.11
+   The `Transform` class is deprecated and will be removed in v1.0.
+   Use `Transformation.from_func()` instead for function-based transformations.
 """
 
 from __future__ import annotations
 
 from typing import Callable, Dict, Optional
 from functools import partial
+import warnings
 
 from koheesio.models import ExtraParamsMixin, Field
 from koheesio.spark import DataFrame
@@ -17,11 +22,28 @@ from koheesio.utils import get_args_for_func
 
 class Transform(Transformation, ExtraParamsMixin):
     """
+    .. deprecated:: 0.11
+       The `Transform` class is deprecated and will be removed in v1.0.
+       Use `Transformation.from_func()` instead.
+
     Transform aims to provide an easy interface for calling transformations on a Spark DataFrame,
     where the transformation is a function that accepts a DataFrame (df) and any number of keyword args.
 
     The implementation is inspired by and based upon:
     https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.transform.html
+
+    Migration Guide
+    ---------------
+    ### Old (v0.10) - using Transform:
+    ```python
+    Transform(func=some_func, a="foo", b="bar")
+    ```
+
+    ### New (v0.11+) - using Transformation.from_func():
+    ```python
+    SomeFunc = Transformation.from_func(some_func)
+    SomeFunc(a="foo", b="bar")
+    ```
 
     Parameters
     ----------
@@ -73,6 +95,13 @@ class Transform(Transformation, ExtraParamsMixin):
     func: Callable = Field(default=..., description="The function to be called on the DataFrame.")
 
     def __init__(self, func: Callable, params: Dict = None, df: Optional[DataFrame] = None, **kwargs: dict):
+        warnings.warn(
+            "Transform is deprecated and will be removed in v1.0. "
+            "Use Transformation.from_func() instead. "
+            "See https://github.com/Nike-Inc/koheesio/discussions/225 for migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         params = {**(params or {}), **kwargs}
         super().__init__(func=func, params=params, df=df)
 

--- a/src/koheesio/spark/transformations/uuid5.py
+++ b/src/koheesio/spark/transformations/uuid5.py
@@ -5,8 +5,9 @@ import uuid
 
 from pyspark.sql import functions as f
 
-from koheesio.models import Field, ListOfColumns, field_validator
+from koheesio.models import Field, field_validator
 from koheesio.spark.transformations import Transformation
+from koheesio.spark.utils.common import ListOfColumns
 
 
 def uuid5_namespace(ns: Optional[Union[str, uuid.UUID]]) -> uuid.UUID:
@@ -120,14 +121,18 @@ class HashUUID5(Transformation):
     """
 
     target_column: str = Field(
-        default=..., description="The generated UUID will be written to the column name specified here"
+        default=...,
+        description="The generated UUID will be written to the column name specified here",
     )
     source_columns: ListOfColumns = Field(
         default=...,
         description="List of columns that should be hashed. Should contain the name of at least 1 column. A list of "
         "columns or a single column can be specified. For example: `['column1', 'column2']` or `'column1'`",
     )
-    delimiter: str = Field(default="|", description="Separator for the string that will eventually be hashed")
+    delimiter: str = Field(
+        default="|",
+        description="Separator for the string that will eventually be hashed",
+    )
     namespace: Optional[Union[str, uuid.UUID]] = Field(default="", description="Namespace DNS")
     extra_string: Optional[str] = Field(
         default="",

--- a/src/koheesio/spark/utils/__init__.py
+++ b/src/koheesio/spark/utils/__init__.py
@@ -1,5 +1,6 @@
 from koheesio.spark.utils.common import (
     SPARK_MINOR_VERSION,
+    ListOfColumns,
     SparkDatatype,
     check_if_pyspark_connect_is_supported,
     check_if_pyspark_connect_module_is_available,
@@ -14,6 +15,7 @@ from koheesio.spark.utils.common import (
 )
 
 __all__ = [
+    "ListOfColumns",
     "SparkDatatype",
     "import_pandas_based_on_pyspark_version",
     "on_databricks",

--- a/src/koheesio/spark/utils/common.py
+++ b/src/koheesio/spark/utils/common.py
@@ -234,9 +234,7 @@ def _list_of_columns_validation(columns_value: Union[str, list, Column, List[Col
             filtered_columns.append(col)
     columns = filtered_columns
 
-    return list(
-        dict.fromkeys(columns)
-    )  # dict.fromkeys is used to dedup while maintaining order
+    return list(dict.fromkeys(columns))  # dict.fromkeys is used to dedup while maintaining order
 
 
 ListOfColumns = Annotated[
@@ -380,12 +378,8 @@ def on_databricks() -> bool:
     """Retrieve if we're running on databricks or elsewhere"""
     dbr_version = os.getenv("DATABRICKS_RUNTIME_VERSION", None)
     spark = get_active_session()
-    dbr_spark_version = spark.conf.get(
-        "spark.databricks.clusterUsageTags.effectiveSparkVersion", None
-    )
-    return (dbr_version is not None and dbr_version != "") or (
-        dbr_spark_version is not None
-    )
+    dbr_spark_version = spark.conf.get("spark.databricks.clusterUsageTags.effectiveSparkVersion", None)
+    return (dbr_version is not None and dbr_version != "") or (dbr_spark_version is not None)
 
 
 def spark_data_type_is_array(data_type: DataType) -> bool:  # type: ignore
@@ -395,18 +389,14 @@ def spark_data_type_is_array(data_type: DataType) -> bool:  # type: ignore
 
 def spark_data_type_is_numeric(data_type: DataType) -> bool:  # type: ignore
     """Check if the column's dataType is of type ArrayType"""
-    return isinstance(
-        data_type, (IntegerType, LongType, FloatType, DoubleType, DecimalType)
-    )
+    return isinstance(data_type, (IntegerType, LongType, FloatType, DoubleType, DecimalType))
 
 
 def schema_struct_to_schema_str(schema: StructType) -> str:
     """Converts a StructType to a schema str"""
     if not schema:
         return ""
-    return ",\n".join(
-        [f"{field.name} {field.dataType.typeName().upper()}" for field in schema.fields]
-    )
+    return ",\n".join([f"{field.name} {field.dataType.typeName().upper()}" for field in schema.fields])
 
 
 def import_pandas_based_on_pyspark_version() -> ModuleType:
@@ -421,9 +411,7 @@ def import_pandas_based_on_pyspark_version() -> ModuleType:
         pyspark_version = get_spark_minor_version()
         pandas_version = pd.__version__
 
-        if (pyspark_version < 3.4 and pandas_version >= "2") or (
-            pyspark_version >= 3.4 and pandas_version < "2"
-        ):
+        if (pyspark_version < 3.4 and pandas_version >= "2") or (pyspark_version >= 3.4 and pandas_version < "2"):
             raise ImportError(
                 f"For PySpark {pyspark_version}, "
                 f"please install Pandas version {'< 2' if pyspark_version < 3.4 else '>= 2'}"
@@ -488,10 +476,7 @@ def get_column_name(col: Column) -> str:  # type: ignore
         # In case of a 'regular' Column object, we can directly access the name attribute through the _jc attribute
         # noinspection PyProtectedMember
         name = col._jc.toString()  # type: ignore[operator]
-    elif any(
-        cls.__module__ == "pyspark.sql.connect.column"
-        for cls in inspect.getmro(col.__class__)
-    ):
+    elif any(cls.__module__ == "pyspark.sql.connect.column" for cls in inspect.getmro(col.__class__)):
         # noinspection PyProtectedMember
         name = col._expr.name()
     else:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -327,8 +327,7 @@ def test_from_yaml_path_object_nonexistent_file():
     except AttributeError as e:
         # If it raises AttributeError, it should NOT be about 'read'
         assert "'read'" not in str(e), (
-            f"Bug #226: from_yaml() should not raise AttributeError about 'read' when passed a Path object. "
-            f"Got: {e}"
+            f"Bug #226: from_yaml() should not raise AttributeError about 'read' when passed a Path object. Got: {e}"
         )
 
 

--- a/tests/spark/transformations/test_decorators.py
+++ b/tests/spark/transformations/test_decorators.py
@@ -1,0 +1,401 @@
+"""
+Tests for decorator-based transformations.
+
+This module tests the @transformation, @column_transformation, and @multi_column_transformation
+decorators, including type validation, equivalence with .from_func(), and all features.
+
+Note: The decorators transform functions into Transformation/ColumnsTransformation classes dynamically.
+IDEs may show type errors for decorated function calls, but this is expected behavior - the decorators
+return classes, not functions. At runtime, the decorated names are classes that accept parameters
+via __init__ (not the original function signature).
+"""
+
+from functools import reduce
+
+from pyspark.sql import functions as f
+
+from koheesio.spark import Column, DataFrame
+from koheesio.spark.transformations import (
+    ColumnsTransformation,
+    Transformation,
+    column_transformation,
+    multi_column_transformation,
+    transformation,
+)
+from koheesio.spark.utils import SparkDatatype
+
+
+class TestTransformationDecorator:
+    """Test @transformation decorator"""
+
+    def test_with_parameters(self, spark):
+        """Test transformation with parameters"""
+
+        @transformation
+        def add_constant(df: DataFrame, value: int) -> DataFrame:
+            return df.withColumn("result", f.lit(value))
+
+        df = spark.range(3)
+
+        # Should work with proper parameter
+        output_df = add_constant(value=100).transform(df)
+
+        assert "result" in output_df.columns
+        assert output_df.select("result").first()[0] == 100
+
+    def test_with_default_parameters(self, spark):
+        """Test decorator with default parameters"""
+
+        @transformation(value=100)
+        def add_constant(df: DataFrame, value: int) -> DataFrame:
+            return df.withColumn("result", f.lit(value))
+
+        df = spark.range(3)
+
+        # Use default value
+        output_df = add_constant().transform(df)
+        assert output_df.select("result").first()[0] == 100
+
+        # Override default
+        output_df = add_constant(value=200).transform(df)
+        assert output_df.select("result").first()[0] == 200
+
+    def test_parameterized_transformation(self, spark):
+        """Test transformation with multiple parameters"""
+
+        @transformation
+        def filter_and_select(
+            df: DataFrame, column: str, threshold: int, select_cols: list
+        ) -> DataFrame:
+            return df.filter(f.col(column) > threshold).select(*select_cols)
+
+        df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["id", "value"])
+        output_df = filter_and_select(
+            column="id", threshold=1, select_cols=["value"]
+        ).transform(df)
+
+        assert output_df.columns == ["value"]
+        assert output_df.count() == 2
+
+
+class TestColumnTransformationDecorator:
+    """Test @column_transformation decorator"""
+
+    def test_simple_column_transformation(self, spark):
+        """Test basic column transformation"""
+
+        @column_transformation
+        def to_upper(col: Column) -> Column:
+            return f.upper(col)
+
+        df = spark.createDataFrame([("hello",), ("world",)], ["name"])
+        output_df = to_upper(columns=["name"]).transform(df)
+
+        assert output_df.select("name").collect()[0][0] == "HELLO"
+        assert output_df.select("name").collect()[1][0] == "WORLD"
+
+    def test_with_columnconfig(self, spark):
+        """Test column transformation with ColumnConfig"""
+
+        @column_transformation(
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+        )
+        def trim_strings(col: Column) -> Column:
+            return f.trim(col)
+
+        df = spark.createDataFrame(
+            [(" hello ", 123, " world ")], ["name", "value", "city"]
+        )
+        output_df = trim_strings().transform(df)
+
+        # Should apply to all string columns
+        assert output_df.select("name").collect()[0][0] == "hello"
+        assert output_df.select("city").collect()[0][0] == "world"
+        # Should not affect non-string column (because of limit_data_type)
+        assert output_df.select("value").collect()[0][0] == 123
+
+    def test_paired_parameters(self, spark):
+        """Test paired parameters"""
+
+        @column_transformation
+        def add_tax(amount: Column, rate: float) -> Column:
+            return amount * (1 + rate)
+
+        df = spark.createDataFrame([(100.0, 200.0)], ["food", "non_food"])
+
+        # Valid: list of floats
+        output_df = add_tax(columns=["food", "non_food"], rate=[0.08, 0.13]).transform(
+            df
+        )
+        assert abs(output_df.select("food").collect()[0][0] - 108.0) < 0.01
+        assert abs(output_df.select("non_food").collect()[0][0] - 226.0) < 0.01
+
+    def test_broadcast_single_value(self, spark):
+        """Test broadcasting single value to all columns"""
+
+        @column_transformation
+        def multiply(col: Column, factor: int) -> Column:
+            return col * factor
+
+        df = spark.createDataFrame([(1, 2, 3)], ["a", "b", "c"])
+        output_df = multiply(columns=["a", "b", "c"], factor=10).transform(df)
+
+        assert output_df.select("a").collect()[0][0] == 10
+        assert output_df.select("b").collect()[0][0] == 20
+        assert output_df.select("c").collect()[0][0] == 30
+
+    def test_explicit_for_each_true(self, spark):
+        """Test explicit for_each=True"""
+
+        @column_transformation(for_each=True)
+        def double(col: Column) -> Column:
+            return col * 2
+
+        df = spark.createDataFrame([(1, 2)], ["a", "b"])
+        output_df = double(columns=["a", "b"]).transform(df)
+
+        assert output_df.select("a").collect()[0][0] == 2
+        assert output_df.select("b").collect()[0][0] == 4
+
+    def test_explicit_for_each_false(self, spark):
+        """Test explicit for_each=False (multi-column mode)"""
+
+        @column_transformation(for_each=False)
+        def sum_two(a: Column, b: Column) -> Column:
+            return a + b
+
+        df = spark.createDataFrame([(1, 2)], ["col_a", "col_b"])
+        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(
+            df
+        )
+
+        assert output_df.select("sum").collect()[0][0] == 3
+
+    def test_with_parameters(self, spark):
+        """Test column transformation with parameters"""
+
+        @column_transformation
+        def add_value(col: Column, value: int) -> Column:
+            return col + value
+
+        df = spark.createDataFrame([(1,)], ["num"])
+
+        # Should work with proper parameter
+        output_df = add_value(columns=["num"], value=5).transform(df)
+        assert output_df.select("num").collect()[0][0] == 6
+
+
+class TestMultiColumnTransformationDecorator:
+    """Test @multi_column_transformation decorator"""
+
+    def test_fixed_arity_aggregation(self, spark):
+        """Test multi-column aggregation with fixed arity"""
+
+        @multi_column_transformation
+        def sum_two(a: Column, b: Column) -> Column:
+            return a + b
+
+        df = spark.createDataFrame([(1, 2)], ["col_a", "col_b"])
+        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(
+            df
+        )
+
+        assert output_df.select("sum").collect()[0][0] == 3
+
+    def test_variadic_aggregation(self, spark):
+        """Test variadic aggregation"""
+
+        @multi_column_transformation
+        def sum_all(*cols: Column) -> Column:
+            return reduce(lambda a, b: a + b, cols)
+
+        df = spark.createDataFrame([(1, 2, 3, 4)], ["a", "b", "c", "d"])
+        output_df = sum_all(
+            columns=["a", "b", "c", "d"], target_column="sum"
+        ).transform(df)
+
+        assert output_df.select("sum").collect()[0][0] == 10
+
+    def test_with_parameters(self, spark):
+        """Test multi-column with parameters"""
+
+        @multi_column_transformation
+        def weighted_sum(a: Column, b: Column, weights: list) -> Column:
+            return a * weights[0] + b * weights[1]
+
+        df = spark.createDataFrame([(10, 20)], ["x", "y"])
+        output_df = weighted_sum(
+            columns=["x", "y"], weights=[0.3, 0.7], target_column="result"
+        ).transform(df)
+
+        assert abs(output_df.select("result").collect()[0][0] - 17.0) < 0.01
+
+    def test_concat_columns(self, spark):
+        """Test concatenating columns"""
+
+        @multi_column_transformation
+        def concat_names(first: Column, last: Column) -> Column:
+            return f.concat(first, f.lit(" "), last)
+
+        df = spark.createDataFrame([("John", "Doe")], ["first_name", "last_name"])
+        output_df = concat_names(
+            columns=["first_name", "last_name"], target_column="full_name"
+        ).transform(df)
+
+        assert output_df.select("full_name").collect()[0][0] == "John Doe"
+
+
+class TestDecoratorEquivalence:
+    """Test that decorators are equivalent to .from_func()"""
+
+    def test_transformation_equivalence(self, spark):
+        """Test @transformation is equivalent to Transformation.from_func()"""
+
+        # Decorator version
+        @transformation
+        def add_col_decorator(df: DataFrame, value: int) -> DataFrame:
+            return df.withColumn("result", f.lit(value))
+
+        # from_func version
+        def add_col_func(df: DataFrame, value: int) -> DataFrame:
+            return df.withColumn("result", f.lit(value))
+
+        AddColFunc = Transformation.from_func(add_col_func)
+
+        df = spark.range(3)
+
+        # Both should produce same result
+        output_decorator = add_col_decorator(value=42).transform(df)
+        output_func = AddColFunc(value=42).transform(df)
+
+        assert output_decorator.collect() == output_func.collect()
+
+    def test_column_transformation_equivalence(self, spark):
+        """Test @column_transformation is equivalent to ColumnsTransformation.from_func()"""
+
+        # Decorator version
+        @column_transformation
+        def to_upper_decorator(col: Column) -> Column:
+            return f.upper(col)
+
+        # from_func version
+        def to_upper_func(col: Column) -> Column:
+            return f.upper(col)
+
+        ToUpperFunc = ColumnsTransformation.from_func(to_upper_func)
+
+        df = spark.createDataFrame([("hello",)], ["name"])
+
+        # Both should produce same result
+        output_decorator = to_upper_decorator(columns=["name"]).transform(df)
+        output_func = ToUpperFunc(columns=["name"]).transform(df)
+
+        assert output_decorator.collect() == output_func.collect()
+
+    def test_multi_column_transformation_equivalence(self, spark):
+        """Test @multi_column_transformation is equivalent to from_multi_column_func()"""
+
+        # Decorator version
+        @multi_column_transformation
+        def sum_decorator(a: Column, b: Column) -> Column:
+            return a + b
+
+        # from_multi_column_func version
+        def sum_func(a: Column, b: Column) -> Column:
+            return a + b
+
+        SumFunc = ColumnsTransformation.from_multi_column_func(sum_func)
+
+        df = spark.createDataFrame([(1, 2)], ["a", "b"])
+
+        # Both should produce same result
+        output_decorator = sum_decorator(
+            columns=["a", "b"], target_column="sum"
+        ).transform(df)
+        output_func = SumFunc(columns=["a", "b"], target_column="sum").transform(df)
+
+        assert output_decorator.collect() == output_func.collect()
+
+
+class TestDecoratorEdgeCases:
+    """Test edge cases and special scenarios"""
+
+    def test_lambda_with_decorator(self, spark):
+        """Test that lambdas work with decorators"""
+
+        @column_transformation
+        def transform(col: Column) -> Column:
+            return f.lower(col)
+
+        # Also test inline lambda
+        ToUpper = column_transformation(lambda col: f.upper(col))
+
+        df = spark.createDataFrame([("Hello",)], ["name"])
+
+        output_lower = transform(columns=["name"]).transform(df)
+        assert output_lower.select("name").collect()[0][0] == "hello"
+
+        output_upper = ToUpper(columns=["name"]).transform(df)
+        assert output_upper.select("name").collect()[0][0] == "HELLO"
+
+    def test_decorator_with_partial(self, spark):
+        """Test using .partial() with decorated transformations"""
+
+        @column_transformation
+        def add_value(col: Column, value: int) -> Column:
+            return col + value
+
+        # Create specialized version
+        AddTen = add_value.partial(value=10)
+
+        df = spark.createDataFrame([(1,), (2,)], ["num"])
+        output_df = AddTen(columns=["num"]).transform(df)
+
+        assert output_df.select("num").collect()[0][0] == 11
+        assert output_df.select("num").collect()[1][0] == 12
+
+    def test_decorator_with_columnconfig_and_limit(self, spark):
+        """Test ColumnConfig with limit_data_type"""
+
+        @column_transformation(
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+            data_type_strict_mode=True,
+        )
+        def process_strings(col: Column) -> Column:
+            return f.upper(col)
+
+        df = spark.createDataFrame([("hello", 123)], ["name", "value"])
+
+        # Should only apply to string columns (due to limit_data_type)
+        output_df = process_strings().transform(df)
+        assert output_df.select("name").collect()[0][0] == "HELLO"
+        # Integer column should be unchanged
+        assert output_df.select("value").collect()[0][0] == 123
+
+    def test_decorator_without_parentheses(self, spark):
+        """Test decorator without parentheses (no arguments)"""
+
+        @transformation
+        def simple_filter(df: DataFrame) -> DataFrame:
+            return df.filter(f.col("id") > 0)
+
+        df = spark.range(-1, 3)  # Creates rows with id: -1, 0, 1, 2
+        output_df = simple_filter().transform(df)
+
+        # Filter > 0 gives: 1, 2 = 2 rows
+        assert output_df.count() == 2
+
+    def test_decorator_with_parentheses_no_args(self, spark):
+        """Test decorator with empty parentheses"""
+
+        @transformation()
+        def simple_filter(df: DataFrame) -> DataFrame:
+            return df.filter(f.col("id") > 0)
+
+        df = spark.range(-1, 3)  # Creates rows with id: -1, 0, 1, 2
+        output_df = simple_filter().transform(df)
+
+        # Filter > 0 gives: 1, 2 = 2 rows
+        assert output_df.count() == 2

--- a/tests/spark/transformations/test_decorators.py
+++ b/tests/spark/transformations/test_decorators.py
@@ -64,15 +64,11 @@ class TestTransformationDecorator:
         """Test transformation with multiple parameters"""
 
         @transformation
-        def filter_and_select(
-            df: DataFrame, column: str, threshold: int, select_cols: list
-        ) -> DataFrame:
+        def filter_and_select(df: DataFrame, column: str, threshold: int, select_cols: list) -> DataFrame:
             return df.filter(f.col(column) > threshold).select(*select_cols)
 
         df = spark.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["id", "value"])
-        output_df = filter_and_select(
-            column="id", threshold=1, select_cols=["value"]
-        ).transform(df)
+        output_df = filter_and_select(column="id", threshold=1, select_cols=["value"]).transform(df)
 
         assert output_df.columns == ["value"]
         assert output_df.count() == 2
@@ -104,9 +100,7 @@ class TestColumnTransformationDecorator:
         def trim_strings(col: Column) -> Column:
             return f.trim(col)
 
-        df = spark.createDataFrame(
-            [(" hello ", 123, " world ")], ["name", "value", "city"]
-        )
+        df = spark.createDataFrame([(" hello ", 123, " world ")], ["name", "value", "city"])
         output_df = trim_strings().transform(df)
 
         # Should apply to all string columns
@@ -125,9 +119,7 @@ class TestColumnTransformationDecorator:
         df = spark.createDataFrame([(100.0, 200.0)], ["food", "non_food"])
 
         # Valid: list of floats
-        output_df = add_tax(columns=["food", "non_food"], rate=[0.08, 0.13]).transform(
-            df
-        )
+        output_df = add_tax(columns=["food", "non_food"], rate=[0.08, 0.13]).transform(df)
         assert abs(output_df.select("food").collect()[0][0] - 108.0) < 0.01
         assert abs(output_df.select("non_food").collect()[0][0] - 226.0) < 0.01
 
@@ -166,9 +158,7 @@ class TestColumnTransformationDecorator:
             return a + b
 
         df = spark.createDataFrame([(1, 2)], ["col_a", "col_b"])
-        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(
-            df
-        )
+        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(df)
 
         assert output_df.select("sum").collect()[0][0] == 3
 
@@ -197,9 +187,7 @@ class TestMultiColumnTransformationDecorator:
             return a + b
 
         df = spark.createDataFrame([(1, 2)], ["col_a", "col_b"])
-        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(
-            df
-        )
+        output_df = sum_two(columns=["col_a", "col_b"], target_column="sum").transform(df)
 
         assert output_df.select("sum").collect()[0][0] == 3
 
@@ -211,9 +199,7 @@ class TestMultiColumnTransformationDecorator:
             return reduce(lambda a, b: a + b, cols)
 
         df = spark.createDataFrame([(1, 2, 3, 4)], ["a", "b", "c", "d"])
-        output_df = sum_all(
-            columns=["a", "b", "c", "d"], target_column="sum"
-        ).transform(df)
+        output_df = sum_all(columns=["a", "b", "c", "d"], target_column="sum").transform(df)
 
         assert output_df.select("sum").collect()[0][0] == 10
 
@@ -225,9 +211,7 @@ class TestMultiColumnTransformationDecorator:
             return a * weights[0] + b * weights[1]
 
         df = spark.createDataFrame([(10, 20)], ["x", "y"])
-        output_df = weighted_sum(
-            columns=["x", "y"], weights=[0.3, 0.7], target_column="result"
-        ).transform(df)
+        output_df = weighted_sum(columns=["x", "y"], weights=[0.3, 0.7], target_column="result").transform(df)
 
         assert abs(output_df.select("result").collect()[0][0] - 17.0) < 0.01
 
@@ -239,9 +223,7 @@ class TestMultiColumnTransformationDecorator:
             return f.concat(first, f.lit(" "), last)
 
         df = spark.createDataFrame([("John", "Doe")], ["first_name", "last_name"])
-        output_df = concat_names(
-            columns=["first_name", "last_name"], target_column="full_name"
-        ).transform(df)
+        output_df = concat_names(columns=["first_name", "last_name"], target_column="full_name").transform(df)
 
         assert output_df.select("full_name").collect()[0][0] == "John Doe"
 
@@ -310,9 +292,7 @@ class TestDecoratorEquivalence:
         df = spark.createDataFrame([(1, 2)], ["a", "b"])
 
         # Both should produce same result
-        output_decorator = sum_decorator(
-            columns=["a", "b"], target_column="sum"
-        ).transform(df)
+        output_decorator = sum_decorator(columns=["a", "b"], target_column="sum").transform(df)
         output_func = SumFunc(columns=["a", "b"], target_column="sum").transform(df)
 
         assert output_decorator.collect() == output_func.collect()

--- a/tests/spark/transformations/test_transformation.py
+++ b/tests/spark/transformations/test_transformation.py
@@ -77,9 +77,7 @@ class TestColumnsTransformation:
 
     @pytest.fixture()
     def add_one_with_target(self, input_df):
-        yield self.AddOneWithTarget(
-            columns=["long_column"], df=input_df, target_column="target_column"
-        )
+        yield self.AddOneWithTarget(columns=["long_column"], df=input_df, target_column="target_column")
 
     def test_columns_transformation_with_target(self, add_one_with_target):
         expected = {"long_column": 1, "str_column": "a", "target_column": 2}
@@ -253,9 +251,7 @@ class TestFunctionBasedTransformations:
         """Test creating a parameterized DataFrame transformation"""
 
         def add_audit_columns(df, user: str, system: str = "koheesio"):
-            return df.withColumn("created_by", f.lit(user)).withColumn(
-                "system", f.lit(system)
-            )
+            return df.withColumn("created_by", f.lit(user)).withColumn("system", f.lit(system))
 
         AddAudit = Transformation.from_func(add_audit_columns)
 
@@ -271,9 +267,7 @@ class TestFunctionBasedTransformations:
         """Test using .partial() to create specialized transformations"""
 
         def add_audit_columns(df, user: str, system: str = "koheesio"):
-            return df.withColumn("created_by", f.lit(user)).withColumn(
-                "system", f.lit(system)
-            )
+            return df.withColumn("created_by", f.lit(user)).withColumn("system", f.lit(system))
 
         AddAudit = Transformation.from_func(add_audit_columns)
         AddMyAudit = AddAudit.partial(user="my_pipeline", system="production")
@@ -336,9 +330,7 @@ class TestFunctionBasedColumnsTransformations:
 
     @pytest.fixture(scope="class")
     def string_df(self, spark):
-        return spark.createDataFrame(
-            [("JOHN", "ENGINEER"), ("JANE", "MANAGER")], ["name", "title"]
-        )
+        return spark.createDataFrame([("JOHN", "ENGINEER"), ("JANE", "MANAGER")], ["name", "title"])
 
     def test_simple_column_transformation(self, string_df):
         """Test creating a simple column transformation"""
@@ -363,9 +355,7 @@ class TestFunctionBasedColumnsTransformations:
             limit_data_type=[SparkDatatype.STRING],
         )
 
-        output_df = LowerCase(columns=["name"], target_column="name_lower").transform(
-            string_df
-        )
+        output_df = LowerCase(columns=["name"], target_column="name_lower").transform(string_df)
 
         assert "name_lower" in output_df.columns
         assert output_df.select("name").first()[0] == "JOHN"  # original unchanged
@@ -443,9 +433,7 @@ class TestFunctionBasedColumnsTransformations:
         )
 
         # Check field defaults
-        assert LowerCase.model_fields["run_for_all_data_type"].default == [
-            SparkDatatype.STRING
-        ]
+        assert LowerCase.model_fields["run_for_all_data_type"].default == [SparkDatatype.STRING]
         assert LowerCase.model_fields["limit_data_type"].default == [
             SparkDatatype.STRING,
             SparkDatatype.INTEGER,
@@ -463,12 +451,8 @@ class TestFunctionBasedColumnsTransformations:
         )
 
         # Verify independence
-        assert LowerCase.model_fields["run_for_all_data_type"].default == [
-            SparkDatatype.STRING
-        ]
-        assert UpperCase.model_fields["run_for_all_data_type"].default == [
-            SparkDatatype.INTEGER
-        ]
+        assert LowerCase.model_fields["run_for_all_data_type"].default == [SparkDatatype.STRING]
+        assert UpperCase.model_fields["run_for_all_data_type"].default == [SparkDatatype.INTEGER]
 
     def test_multiple_columns_with_target_suffix(self, string_df):
         """Test that target_column becomes a suffix when multiple columns are given"""
@@ -476,9 +460,7 @@ class TestFunctionBasedColumnsTransformations:
             lambda col: f.lower(col), run_for_all_data_type=[SparkDatatype.STRING]
         )
 
-        output_df = LowerCase(
-            columns=["name", "title"], target_column="lower"
-        ).transform(string_df)
+        output_df = LowerCase(columns=["name", "title"], target_column="lower").transform(string_df)
 
         # Target column should be used as suffix
         assert "name_lower" in output_df.columns
@@ -524,12 +506,8 @@ class TestFunctionBasedColumnsTransformations:
 
         ConcatNames = ColumnsTransformation.from_func(concat_names)
 
-        df = spark.createDataFrame(
-            [("John", "Doe"), ("Jane", "Smith")], ["first_name", "last_name"]
-        )
-        output_df = ConcatNames(
-            columns=["first_name", "last_name"], target_column="full_name"
-        ).transform(df)
+        df = spark.createDataFrame([("John", "Doe"), ("Jane", "Smith")], ["first_name", "last_name"])
+        output_df = ConcatNames(columns=["first_name", "last_name"], target_column="full_name").transform(df)
 
         assert "full_name" in output_df.columns
         assert output_df.select("full_name").collect()[0][0] == "John Doe"
@@ -551,9 +529,7 @@ class TestFunctionBasedColumnsTransformations:
 
         # Test with 4 columns
         df = spark.createDataFrame([(1, 2, 3, 4)], ["a", "b", "c", "d"])
-        output_df = SumAll(columns=["a", "b", "c", "d"], target_column="sum").transform(
-            df
-        )
+        output_df = SumAll(columns=["a", "b", "c", "d"], target_column="sum").transform(df)
         assert output_df.select("sum").collect()[0][0] == 10
 
     def test_paired_parameters_exact_match(self, spark):
@@ -565,16 +541,12 @@ class TestFunctionBasedColumnsTransformations:
         AddTax = ColumnsTransformation.from_func(add_tax)
 
         df = spark.createDataFrame([(100.0, 200.0)], ["food_price", "non_food_price"])
-        output_df = AddTax(
-            columns=["food_price", "non_food_price"], rate=[0.08, 0.13]
-        ).transform(df)
+        output_df = AddTax(columns=["food_price", "non_food_price"], rate=[0.08, 0.13]).transform(df)
 
         # food_price: 100 * 1.08 = 108.0
         # non_food_price: 200 * 1.13 = 226.0
         assert output_df.select("food_price").collect()[0][0] == pytest.approx(108.0)
-        assert output_df.select("non_food_price").collect()[0][0] == pytest.approx(
-            226.0
-        )
+        assert output_df.select("non_food_price").collect()[0][0] == pytest.approx(226.0)
 
     def test_paired_parameters_length_mismatch(self, spark):
         """Test that mismatched list length raises error (strict=True)"""
@@ -613,9 +585,7 @@ class TestFunctionBasedColumnsTransformations:
         ScaleOffset = ColumnsTransformation.from_func(scale_offset)
 
         df = spark.createDataFrame([(10.0, 20.0)], ["a", "b"])
-        output_df = ScaleOffset(
-            columns=["a", "b"], scale=[2.0, 3.0], offset=[5.0, 10.0]
-        ).transform(df)
+        output_df = ScaleOffset(columns=["a", "b"], scale=[2.0, 3.0], offset=[5.0, 10.0]).transform(df)
 
         # a: 10 * 2.0 + 5.0 = 25.0
         # b: 20 * 3.0 + 10.0 = 70.0
@@ -696,9 +666,7 @@ class TestFunctionBasedColumnsTransformations:
         ConcatThree = ColumnsTransformation.from_multi_column_func(concat_three)
 
         df = spark.createDataFrame([("a", "b", "c")], ["col1", "col2", "col3"])
-        output_df = ConcatThree(
-            columns=["col1", "col2", "col3"], target_column="result"
-        ).transform(df)
+        output_df = ConcatThree(columns=["col1", "col2", "col3"], target_column="result").transform(df)
 
         assert output_df.select("result").collect()[0][0] == "a-b-c"
 

--- a/tests/spark/transformations/test_transformation.py
+++ b/tests/spark/transformations/test_transformation.py
@@ -6,6 +6,7 @@ from pyspark.sql import functions as f
 from koheesio.spark.transformations import (
     ColumnsTransformation,
     ColumnsTransformationWithTarget,
+    Transformation,
 )
 from koheesio.spark.transformations.dummy import DummyTransformation
 from koheesio.spark.utils import SparkDatatype
@@ -31,8 +32,8 @@ def test_transform_unhappy():
 
 def test_execute(dummy_df):
     tf = DummyTransformation(df=dummy_df)
-    output = tf.execute()
-    df = output.df
+    tf.execute()
+    df = tf.output.df
     actual = df.head().asDict()
     expected = {"id": 0, "hello": "world"}
     assert actual == expected
@@ -59,7 +60,8 @@ class TestColumnsTransformation:
 
     def test_columns_transformation(self, add_one):
         expected = {"str_column": "a", "long_column": 2}
-        output_df = add_one.execute().df
+        add_one.execute()
+        output_df = add_one.output.df
         actual = output_df.head().asDict()
         assert actual == expected
 
@@ -75,11 +77,14 @@ class TestColumnsTransformation:
 
     @pytest.fixture()
     def add_one_with_target(self, input_df):
-        yield self.AddOneWithTarget(columns=["long_column"], df=input_df, target_column="target_column")
+        yield self.AddOneWithTarget(
+            columns=["long_column"], df=input_df, target_column="target_column"
+        )
 
     def test_columns_transformation_with_target(self, add_one_with_target):
         expected = {"long_column": 1, "str_column": "a", "target_column": 2}
-        output_df = add_one_with_target.execute().df
+        add_one_with_target.execute()
+        output_df = add_one_with_target.output.df
         actual = output_df.head().asDict()
         assert actual == expected
 
@@ -191,10 +196,16 @@ class TestColumnsTransformationDataTypeLimitations:
         assert multiple_data_types.ColumnConfig.data_type_strict_mode is True
 
         assert multiple_data_types.limit_data_type_is_set is True
-        assert multiple_data_types.ColumnConfig.limit_data_type == [SparkDatatype.LONG, SparkDatatype.STRING]
+        assert multiple_data_types.ColumnConfig.limit_data_type == [
+            SparkDatatype.LONG,
+            SparkDatatype.STRING,
+        ]
 
         assert multiple_data_types.run_for_all_is_set is True
-        assert multiple_data_types.ColumnConfig.run_for_all_data_type == [SparkDatatype.LONG, SparkDatatype.STRING]
+        assert multiple_data_types.ColumnConfig.run_for_all_data_type == [
+            SparkDatatype.LONG,
+            SparkDatatype.STRING,
+        ]
 
         actual = [col for col in multiple_data_types.get_columns()]
         expected = ["str_column", "long_column"]
@@ -207,5 +218,549 @@ class TestColumnsTransformationDataTypeLimitations:
 
         tf = TestTransformation(columns=["non_existent_column"], df=str_long_df)
 
-        with pytest.raises(ValueError, match="Column 'non_existent_column' does not exist in the DataFrame schema"):
+        with pytest.raises(
+            ValueError,
+            match="Column 'non_existent_column' does not exist in the DataFrame schema",
+        ):
             tf.column_type_of_col("non_existent_column")
+
+
+class TestFunctionBasedTransformations:
+    """Test function-based transformations using Transformation.from_func()"""
+
+    def test_simple_dataframe_transformation(self, spark):
+        """Test creating a simple DataFrame transformation from a function"""
+
+        # Define a function
+        def lowercase_columns(df):
+            return df.select([f.col(c).alias(c.lower()) for c in df.columns])
+
+        # Create transformation
+        LowercaseColumns = Transformation.from_func(lowercase_columns)
+
+        # Verify it's a proper class
+        assert issubclass(LowercaseColumns, Transformation)
+        assert LowercaseColumns.__name__ == "lowercase_columns"
+
+        # Test it works
+        input_df = spark.createDataFrame([("John", 25)], ["NAME", "AGE"])
+        output_df = LowercaseColumns().transform(input_df)
+
+        assert output_df.columns == ["name", "age"]
+        assert output_df.count() == 1
+
+    def test_parameterized_dataframe_transformation(self, spark):
+        """Test creating a parameterized DataFrame transformation"""
+
+        def add_audit_columns(df, user: str, system: str = "koheesio"):
+            return df.withColumn("created_by", f.lit(user)).withColumn(
+                "system", f.lit(system)
+            )
+
+        AddAudit = Transformation.from_func(add_audit_columns)
+
+        input_df = spark.createDataFrame([("John", 25)], ["name", "age"])
+        output_df = AddAudit(user="test_user", system="test_system").transform(input_df)
+
+        assert "created_by" in output_df.columns
+        assert "system" in output_df.columns
+        assert output_df.select("created_by").first()[0] == "test_user"
+        assert output_df.select("system").first()[0] == "test_system"
+
+    def test_transformation_partial(self, spark):
+        """Test using .partial() to create specialized transformations"""
+
+        def add_audit_columns(df, user: str, system: str = "koheesio"):
+            return df.withColumn("created_by", f.lit(user)).withColumn(
+                "system", f.lit(system)
+            )
+
+        AddAudit = Transformation.from_func(add_audit_columns)
+        AddMyAudit = AddAudit.partial(user="my_pipeline", system="production")
+
+        input_df = spark.createDataFrame([("John", 25)], ["name", "age"])
+        output_df = AddMyAudit().transform(input_df)
+
+        assert output_df.select("created_by").first()[0] == "my_pipeline"
+        assert output_df.select("system").first()[0] == "production"
+
+    def test_lambda_transformation_naming(self):
+        """Test that lambda functions get a generic name"""
+        LambdaTransform = Transformation.from_func(lambda df: df)
+        assert LambdaTransform.__name__ == "FunctionBasedTransformation"
+
+    def test_lambda_transformation_custom_name(self):
+        """Test that lambda transformations respect a custom instance name"""
+
+        LambdaTransform = Transformation.from_func(lambda df: df)
+        instance = LambdaTransform(name="custom_lambda")
+
+        # Class name stays generic
+        assert LambdaTransform.__name__ == "FunctionBasedTransformation"
+        # Instance name reflects the explicit override
+        assert instance.name == "custom_lambda"
+
+    def test_named_function_transformation_naming(self):
+        """Test that named functions preserve their class and default instance name"""
+
+        def my_custom_transform(df):
+            return df
+
+        NamedTransform = Transformation.from_func(my_custom_transform)
+        # Class name should reflect the original function name
+        assert NamedTransform.__name__ == "my_custom_transform"
+
+        # Default instance name should also be derived from the class name
+        default_instance = NamedTransform()
+        assert default_instance.name == "my_custom_transform"
+
+    def test_named_function_transformation_custom_name(self):
+        """Test that passing a custom name parameter overrides the default instance name"""
+
+        def my_custom_transform(df):
+            return df
+
+        NamedTransform = Transformation.from_func(my_custom_transform)
+
+        # Default instance name is derived from the class name
+        default_instance = NamedTransform()
+        assert default_instance.name == "my_custom_transform"
+
+        # Instance-level name should reflect the explicitly provided value
+        custom_instance = NamedTransform(name="custom_name")
+        assert custom_instance.name == "custom_name"
+
+
+class TestFunctionBasedColumnsTransformations:
+    """Test function-based column transformations using ColumnsTransformation.from_func()"""
+
+    @pytest.fixture(scope="class")
+    def string_df(self, spark):
+        return spark.createDataFrame(
+            [("JOHN", "ENGINEER"), ("JANE", "MANAGER")], ["name", "title"]
+        )
+
+    def test_simple_column_transformation(self, string_df):
+        """Test creating a simple column transformation"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col),
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+        )
+
+        assert issubclass(LowerCase, ColumnsTransformation)
+
+        # Apply to specific column
+        output_df = LowerCase(columns=["name"]).transform(string_df)
+        assert output_df.select("name").first()[0] == "john"
+        assert output_df.select("title").first()[0] == "ENGINEER"  # unchanged
+
+    def test_column_transformation_with_target(self, string_df):
+        """Test column transformation with target_column"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col),
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+        )
+
+        output_df = LowerCase(columns=["name"], target_column="name_lower").transform(
+            string_df
+        )
+
+        assert "name_lower" in output_df.columns
+        assert output_df.select("name").first()[0] == "JOHN"  # original unchanged
+        assert output_df.select("name_lower").first()[0] == "john"
+
+    def test_column_transformation_run_for_all(self, string_df):
+        """Test automatic column selection with run_for_all_data_type"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col),
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING],
+        )
+
+        # Don't specify columns - should apply to all STRING columns
+        output_df = LowerCase().transform(string_df)
+
+        assert output_df.select("name").first()[0] == "john"
+        assert output_df.select("title").first()[0] == "engineer"
+
+    def test_parameterized_column_transformation(self, string_df):
+        """Test parameterized column transformation"""
+
+        def add_prefix(col, prefix: str):
+            return f.concat(f.lit(prefix), col)
+
+        AddPrefix = ColumnsTransformation.from_func(add_prefix)
+
+        output_df = AddPrefix(columns=["name"], prefix="Mr. ").transform(string_df)
+        assert output_df.select("name").first()[0] == "Mr. JOHN"
+
+    def test_column_transformation_partial(self, string_df):
+        """Test using .partial() with column transformations"""
+
+        def add_prefix(col, prefix: str):
+            return f.concat(f.lit(prefix), col)
+
+        AddPrefix = ColumnsTransformation.from_func(add_prefix)
+        AddMrPrefix = AddPrefix.partial(prefix="Mr. ")
+
+        output_df = AddMrPrefix(columns=["name"]).transform(string_df)
+        assert output_df.select("name").first()[0] == "Mr. JOHN"
+
+    def test_factory_pattern(self, string_df):
+        """Test factory pattern for creating related transformations"""
+
+        def string_transform(func):
+            return ColumnsTransformation.from_func(
+                func,
+                run_for_all_data_type=[SparkDatatype.STRING],
+                limit_data_type=[SparkDatatype.STRING],
+            )
+
+        LowerCase = string_transform(lambda col: f.lower(col))
+        UpperCase = string_transform(lambda col: f.upper(col))
+        TitleCase = string_transform(lambda col: f.initcap(col))
+
+        # Test they're independent
+        assert LowerCase is not UpperCase
+        assert LowerCase is not TitleCase
+
+        # Test they work
+        lower_df = LowerCase(columns=["name"]).transform(string_df)
+        assert lower_df.select("name").first()[0] == "john"
+
+        upper_df = UpperCase(columns=["name"]).transform(string_df)
+        assert upper_df.select("name").first()[0] == "JOHN"
+
+    def test_column_config_fields_set_correctly(self, string_df):
+        """Test that ColumnConfig parameters are set correctly on generated classes"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col),
+            run_for_all_data_type=[SparkDatatype.STRING],
+            limit_data_type=[SparkDatatype.STRING, SparkDatatype.INTEGER],
+            data_type_strict_mode=True,
+        )
+
+        # Check field defaults
+        assert LowerCase.model_fields["run_for_all_data_type"].default == [
+            SparkDatatype.STRING
+        ]
+        assert LowerCase.model_fields["limit_data_type"].default == [
+            SparkDatatype.STRING,
+            SparkDatatype.INTEGER,
+        ]
+        assert LowerCase.model_fields["data_type_strict_mode"].default is True
+
+    def test_column_config_independence(self):
+        """Test that different generated classes have independent ColumnConfig"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col), run_for_all_data_type=[SparkDatatype.STRING]
+        )
+
+        UpperCase = ColumnsTransformation.from_func(
+            lambda col: f.upper(col), run_for_all_data_type=[SparkDatatype.INTEGER]
+        )
+
+        # Verify independence
+        assert LowerCase.model_fields["run_for_all_data_type"].default == [
+            SparkDatatype.STRING
+        ]
+        assert UpperCase.model_fields["run_for_all_data_type"].default == [
+            SparkDatatype.INTEGER
+        ]
+
+    def test_multiple_columns_with_target_suffix(self, string_df):
+        """Test that target_column becomes a suffix when multiple columns are given"""
+        LowerCase = ColumnsTransformation.from_func(
+            lambda col: f.lower(col), run_for_all_data_type=[SparkDatatype.STRING]
+        )
+
+        output_df = LowerCase(
+            columns=["name", "title"], target_column="lower"
+        ).transform(string_df)
+
+        # Target column should be used as suffix
+        assert "name_lower" in output_df.columns
+        assert "title_lower" in output_df.columns
+        assert output_df.select("name_lower").first()[0] == "john"
+        assert output_df.select("title_lower").first()[0] == "engineer"
+
+    def test_backward_compatibility_with_subclasses(self, string_df):
+        """Test that existing subclass-based transformations still work (backward compatibility)"""
+
+        class LowerCaseOldStyle(ColumnsTransformationWithTarget):
+            class ColumnConfig:
+                run_for_all_data_type = [SparkDatatype.STRING]
+                limit_data_type = [SparkDatatype.STRING]
+
+            def func(self, column: Column):
+                return f.lower(column)
+
+        # Old style should still work
+        output_df = LowerCaseOldStyle(columns=["name"]).transform(string_df)
+        assert output_df.select("name").first()[0] == "john"
+
+    def test_multi_column_aggregation(self, spark):
+        """Test multi-column aggregation pattern"""
+
+        def sum_columns(col1: Column, col2: Column, col3: Column) -> Column:
+            return col1 + col2 + col3
+
+        SumThree = ColumnsTransformation.from_func(sum_columns)
+
+        df = spark.createDataFrame([(1, 2, 3), (4, 5, 6)], ["a", "b", "c"])
+        output_df = SumThree(columns=["a", "b", "c"], target_column="sum").transform(df)
+
+        assert "sum" in output_df.columns
+        assert output_df.select("sum").collect()[0][0] == 6
+        assert output_df.select("sum").collect()[1][0] == 15
+
+    def test_multi_column_concat(self, spark):
+        """Test multi-column concatenation"""
+
+        def concat_names(first: Column, last: Column) -> Column:
+            return f.concat(first, f.lit(" "), last)
+
+        ConcatNames = ColumnsTransformation.from_func(concat_names)
+
+        df = spark.createDataFrame(
+            [("John", "Doe"), ("Jane", "Smith")], ["first_name", "last_name"]
+        )
+        output_df = ConcatNames(
+            columns=["first_name", "last_name"], target_column="full_name"
+        ).transform(df)
+
+        assert "full_name" in output_df.columns
+        assert output_df.select("full_name").collect()[0][0] == "John Doe"
+        assert output_df.select("full_name").collect()[1][0] == "Jane Smith"
+
+    def test_variadic_args(self, spark):
+        """Test variadic *args pattern"""
+        from functools import reduce
+
+        def sum_all(*cols: Column) -> Column:
+            return reduce(lambda a, b: a + b, cols)
+
+        SumAll = ColumnsTransformation.from_func(sum_all)
+
+        # Test with 3 columns
+        df = spark.createDataFrame([(1, 2, 3)], ["a", "b", "c"])
+        output_df = SumAll(columns=["a", "b", "c"], target_column="sum").transform(df)
+        assert output_df.select("sum").collect()[0][0] == 6
+
+        # Test with 4 columns
+        df = spark.createDataFrame([(1, 2, 3, 4)], ["a", "b", "c", "d"])
+        output_df = SumAll(columns=["a", "b", "c", "d"], target_column="sum").transform(
+            df
+        )
+        assert output_df.select("sum").collect()[0][0] == 10
+
+    def test_paired_parameters_exact_match(self, spark):
+        """Test paired parameters with exact column count match"""
+
+        def add_tax(amount: Column, rate: float = 0.08) -> Column:
+            return amount * (1 + rate)
+
+        AddTax = ColumnsTransformation.from_func(add_tax)
+
+        df = spark.createDataFrame([(100.0, 200.0)], ["food_price", "non_food_price"])
+        output_df = AddTax(
+            columns=["food_price", "non_food_price"], rate=[0.08, 0.13]
+        ).transform(df)
+
+        # food_price: 100 * 1.08 = 108.0
+        # non_food_price: 200 * 1.13 = 226.0
+        assert output_df.select("food_price").collect()[0][0] == pytest.approx(108.0)
+        assert output_df.select("non_food_price").collect()[0][0] == pytest.approx(
+            226.0
+        )
+
+    def test_paired_parameters_length_mismatch(self, spark):
+        """Test that mismatched list length raises error (strict=True)"""
+
+        def add_tax(amount: Column, rate: float = 0.08) -> Column:
+            return amount * (1 + rate)
+
+        AddTax = ColumnsTransformation.from_func(add_tax)
+
+        df = spark.createDataFrame([(100.0, 200.0, 300.0)], ["a", "b", "c"])
+
+        with pytest.raises(ValueError, match="has 2 values but 3 columns provided"):
+            AddTax(columns=["a", "b", "c"], rate=[0.08, 0.13]).transform(df)
+
+    def test_paired_parameters_single_value_broadcast(self, spark):
+        """Test that single values are broadcast to all columns"""
+
+        def add_tax(amount: Column, rate: float = 0.08) -> Column:
+            return amount * (1 + rate)
+
+        AddTax = ColumnsTransformation.from_func(add_tax)
+
+        df = spark.createDataFrame([(100.0, 200.0)], ["a", "b"])
+        output_df = AddTax(columns=["a", "b"], rate=0.10).transform(df)
+
+        # Both should get 10% tax
+        assert output_df.select("a").collect()[0][0] == pytest.approx(110.0)
+        assert output_df.select("b").collect()[0][0] == pytest.approx(220.0)
+
+    def test_paired_multiple_parameters(self, spark):
+        """Test multiple paired parameters"""
+
+        def scale_offset(col: Column, scale: float, offset: float) -> Column:
+            return col * scale + offset
+
+        ScaleOffset = ColumnsTransformation.from_func(scale_offset)
+
+        df = spark.createDataFrame([(10.0, 20.0)], ["a", "b"])
+        output_df = ScaleOffset(
+            columns=["a", "b"], scale=[2.0, 3.0], offset=[5.0, 10.0]
+        ).transform(df)
+
+        # a: 10 * 2.0 + 5.0 = 25.0
+        # b: 20 * 3.0 + 10.0 = 70.0
+        assert output_df.select("a").collect()[0][0] == 25.0
+        assert output_df.select("b").collect()[0][0] == 70.0
+
+    def test_columns_transformation_with_target_still_works(self, spark):
+        """Test that ColumnsTransformationWithTarget still works (backward compatibility)"""
+        # Note: Deprecated in docstring only, no runtime warning to avoid spamming users
+        # with warnings from Koheesio's own internal classes
+
+        class MyTransform(ColumnsTransformationWithTarget):
+            def func(self, col):
+                return f.upper(col)
+
+        df = spark.createDataFrame([("hello",)], ["text"])
+        output_df = MyTransform(columns=["text"]).transform(df)
+        assert output_df.select("text").collect()[0][0] == "HELLO"
+
+    def test_nested_columnconfig_backward_compatibility(self, spark):
+        """Test that nested ColumnConfig still works (backward compatibility)"""
+
+        class OldStyle(ColumnsTransformation):
+            class ColumnConfig:
+                run_for_all_data_type = [SparkDatatype.STRING]
+                limit_data_type = None
+                data_type_strict_mode = False
+
+            def execute(self):
+                # Simple transformation for testing
+                for col in self.get_columns():
+                    self.output.df = self.df.withColumn(col, f.upper(f.col(col)))
+
+        df = spark.createDataFrame([("test",)], ["col"])
+        transform = OldStyle(df=df)
+        transform.execute()
+        output_df = transform.output.df
+
+        # Verify it still works
+        assert output_df.select("col").collect()[0][0] == "TEST"
+
+    def test_for_each_explicit_true(self, spark):
+        """Test explicit for_each=True parameter"""
+
+        def add_one(col: Column) -> Column:
+            return col + 1
+
+        AddOne = ColumnsTransformation.from_func(add_one, for_each=True)
+
+        df = spark.createDataFrame([(1, 2), (3, 4)], ["a", "b"])
+        output_df = AddOne(columns=["a", "b"]).transform(df)
+
+        # Should apply to each column separately
+        assert output_df.select("a").collect()[0][0] == 2
+        assert output_df.select("b").collect()[0][0] == 3
+
+    def test_for_each_explicit_false(self, spark):
+        """Test explicit for_each=False parameter"""
+
+        def sum_two(col1: Column, col2: Column) -> Column:
+            return col1 + col2
+
+        SumTwo = ColumnsTransformation.from_func(sum_two, for_each=False)
+
+        df = spark.createDataFrame([(1, 2), (3, 4)], ["a", "b"])
+        output_df = SumTwo(columns=["a", "b"], target_column="sum").transform(df)
+
+        # Should pass both columns at once
+        assert output_df.select("sum").collect()[0][0] == 3
+        assert output_df.select("sum").collect()[1][0] == 7
+
+    def test_from_multi_column_func_method(self, spark):
+        """Test from_multi_column_func method"""
+
+        def concat_three(c1: Column, c2: Column, c3: Column) -> Column:
+            return f.concat(c1, f.lit("-"), c2, f.lit("-"), c3)
+
+        ConcatThree = ColumnsTransformation.from_multi_column_func(concat_three)
+
+        df = spark.createDataFrame([("a", "b", "c")], ["col1", "col2", "col3"])
+        output_df = ConcatThree(
+            columns=["col1", "col2", "col3"], target_column="result"
+        ).transform(df)
+
+        assert output_df.select("result").collect()[0][0] == "a-b-c"
+
+    def test_from_multi_column_func_default_behavior(self, spark):
+        """Test that from_multi_column_func defaults to for_each=False for ambiguous functions"""
+
+        # No type hints - ambiguous
+        def mystery_add(a, b):
+            return a + b
+
+        # from_func should default to True (column-wise)
+        # AddFunc = ColumnsTransformation.from_func(mystery_add)  # Not used
+        df = spark.createDataFrame([(1, 2)], ["a", "b"])
+        # This would fail if it tried to apply column-wise since we need target_column
+        # So let's use explicit for_each to test
+        AddFunc2 = ColumnsTransformation.from_func(mystery_add, for_each=False)
+        output_df = AddFunc2(columns=["a", "b"], target_column="sum").transform(df)
+        assert output_df.select("sum").collect()[0][0] == 3
+
+        # from_multi_column_func should default to False (multi-column)
+        AddMulti = ColumnsTransformation.from_multi_column_func(mystery_add)
+        output_df2 = AddMulti(columns=["a", "b"], target_column="sum").transform(df)
+        assert output_df2.select("sum").collect()[0][0] == 3
+
+    def test_auto_detect_single_column_param(self, spark):
+        """Test auto-detection with single Column parameter"""
+
+        def double_it(col: Column) -> Column:
+            return col * 2
+
+        Double = ColumnsTransformation.from_func(double_it)
+
+        df = spark.createDataFrame([(5, 10)], ["a", "b"])
+        output_df = Double(columns=["a", "b"]).transform(df)
+
+        # Should apply to each column
+        assert output_df.select("a").collect()[0][0] == 10
+        assert output_df.select("b").collect()[0][0] == 20
+
+    def test_auto_detect_multiple_column_params(self, spark):
+        """Test auto-detection with multiple Column parameters"""
+
+        def multiply_cols(col1: Column, col2: Column) -> Column:
+            return col1 * col2
+
+        Multiply = ColumnsTransformation.from_func(multiply_cols)
+
+        df = spark.createDataFrame([(2, 3), (4, 5)], ["a", "b"])
+        output_df = Multiply(columns=["a", "b"], target_column="product").transform(df)
+
+        # Should pass both columns at once
+        assert output_df.select("product").collect()[0][0] == 6
+        assert output_df.select("product").collect()[1][0] == 20
+
+    def test_lambda_with_for_each_override(self, spark):
+        """Test lambda function with explicit for_each override"""
+
+        # Lambda with 2 params - ambiguous without type hints
+        SumLambda = ColumnsTransformation.from_func(lambda a, b: a + b, for_each=False)
+
+        df = spark.createDataFrame([(1, 2), (3, 4)], ["x", "y"])
+        output_df = SumLambda(columns=["x", "y"], target_column="sum").transform(df)
+
+        assert output_df.select("sum").collect()[0][0] == 3
+        assert output_df.select("sum").collect()[1][0] == 7


### PR DESCRIPTION
**Overview**

This PR implements the first phase of [RFC: Function-Based Transformations for Koheesio 0.11](https://github.com/Nike-Inc/koheesio/discussions/225), introducing function-based and decorator-based Spark transformations while maintaining full backward compatibility with existing class-based patterns.
It also fixes a core bug in `Context.from_yaml()` and hardens the `ListOfColumns` validation used across Spark utilities and transformations.

**Motivation & RFC alignment**

- Implements RFC 225 to:
  - Add function-based transformation support on top of existing `Transformation` and `ColumnsTransformation`.
  - Reduce boilerplate for simple transformations while preserving Koheesio’s existing patterns (`.partial()`, `ExtraParamsMixin`, ColumnConfig).
  - Lay the groundwork for a future 1.0 cleanup that unifies the transformation hierarchy and removes legacy classes.
- Keeps RFC’s Phase 1 promise: 0.11 remains non-breaking, with deprecations and a clear migration path rather than removals.

**Changes**

- **New APIs: Function-based transformations**
  - `Transformation.from_func(func, **defaults)`
    - Wraps `func(df: DataFrame, **params) -> DataFrame` into a `Transformation` subclass.
    - Supports `.partial()` for specialized variants, leveraging `BaseModel.partial`.
  - `ColumnsTransformation.from_func(func, run_for_all_data_type=None, limit_data_type=None, data_type_strict_mode=False, for_each=None, **defaults)`
    - Works for simple per-column transforms, multi-column aggregations, and factory patterns.
    - Fully supports ColumnConfig semantics as Pydantic fields:
      - `run_for_all_data_type`, `limit_data_type`, `data_type_strict_mode`.
    - Automatically detects column-wise vs multi-column behavior from type hints / signature, with explicit `for_each` override.
  - `ColumnsTransformation.from_multi_column_func(...)`
    - Mirrors `from_func()` but defaults ambiguous functions to multi-column (`for_each=False`), matching the RFC’s N→1 aggregation use cases.

- **New APIs: Decorator-based transformations** (built on the `.from_func()` APIs)
  - `@transformation` – DataFrame-level transforms from `func(df, ...) -> DataFrame`, with Pydantic validation.
  - `@column_transformation` – Column-level transforms from `func(col: Column, ...) -> Column`:
    - Full ColumnConfig support (automatic column selection, type restrictions, strict mode).
    - Paired parameters with strict list-length checks (like `zip(..., strict=True)`).
  - `@multi_column_transformation` – Explicit N-column → 1-column aggregations.
  - Decorators are tested for equivalence with the corresponding `.from_func()` implementations in `tests/spark/transformations/test_decorators.py`.
  
  *Note*: this was not in the RFC originally, but it made sense to add this pattern while implementing this code.

- **ColumnConfig & `ListOfColumns`**
  - `ColumnsTransformation` now exposes ColumnConfig as first-class Pydantic fields:
    - `run_for_all_data_type: Optional[List[SparkDatatype]]`
    - `limit_data_type: Optional[List[SparkDatatype]]`
    - `data_type_strict_mode: bool`
  - Instance fields take precedence; nested `ColumnConfig` remains supported for backward compatibility and is documented as deprecated.
  - `ListOfColumns`:
    - Refactored into `koheesio.spark.utils.common` with an annotated type that accepts `str`, `List[str]`, `Column`, or `List[Column]`.
    - Coerces single values to lists, deduplicates while preserving order.
    - Crucially avoids `if col` on PySpark `Column` objects, preventing `CANNOT_CONVERT_COLUMN_INTO_BOOL`.
    - Re-exported via `koheesio.spark.utils` and used consistently (e.g. `HashUUID5`, `DeltaTableReader`, column transformations).

- **Deprecations (Phase 1 toward a future 1.0)**
  - `Transform` (`spark/transformations/transform.py`):
    - Marked deprecated in favor of `Transformation.from_func()`.
    - Emits a `DeprecationWarning` on instantiation, pointing to RFC 225.
  - `ColumnsTransformationWithTarget`:
    - Marked deprecated; its target-column semantics are available via `ColumnsTransformation.from_func()` + `target_column`.
  - Nested `ColumnConfig` classes:
    - Marked deprecated; field-based configuration on `ColumnsTransformation` is the recommended pattern.
  - All of the above remain functional in 0.11; the deprecation timeline and migration path are documented in `docs/releases/0.11.md`.

- **Bugfixes included**
  - **Core > Models / Spark Utils: `ListOfColumns` with PySpark `Column` objects**
    - Fixed `ListOfColumns` validation to handle `Column` instances without converting them to `bool`, eliminating `CANNOT_CONVERT_COLUMN_INTO_BOOL`.
    - Centralized `_list_of_columns_validation` in `koheesio.spark.utils.common` and wired it into the new `ListOfColumns` annotated type.
    - All call-sites updated to use the shared implementation.
    - Fixes: #222

**Backwards compatibility**

All changes are (mostly) backwards compatible, with the exception of `ListOfColumns` - this had to be moved inside the Spark package to ensure that we have the right dependencies available to run type chacking at runtime.

- All existing `Transformation`, `ColumnsTransformation`, and `ColumnsTransformationWithTarget` subclasses continue to work unchanged.
- `Transform` and nested `ColumnConfig` remain available but are clearly marked as deprecated in code and in `docs/releases/0.11.md`.
- New function-based and decorator-based APIs are additive and non-breaking for existing users.

**Testing**

- Extended/added tests:
  - `tests/spark/transformations/test_transformation.py` – function-based transformations (DataFrame & column, ColumnConfig, multi-column, variadic, paired parameters, backwards compatibility).
  - `tests/spark/transformations/test_decorators.py` – decorator behavior and equivalence with `.from_func()`.
  - `tests/core/test_context.py` – regression for `Context.from_yaml()` with `Path` inputs.
- Existing tests for transformations and integrations continue to pass.

**Future work**

Follow-up work around RFC 225 for 0.11 preparation and 1.0 planning is tracked in the issue
“[FEATURE] RFC 225 follow-up: finalize function-based transformations & deprecation path for Koheesio 0.11”.
