### PR TITLE
chore: Refactor makefile and update dependencies in pyproject.toml

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,7 +30,11 @@ dev: hatch-version
 	@echo "\033[3mThe virtual environment is available in the \033[0;95m'.venv'\033[0m\033[3m folder\033[0m"
 	@echo "\033[0;34mHappy coding! 🚀"
 	@echo "\033[0m"
-	@hatch shell dev
+	@if [ "$$HATCH_ENV_ACTIVE" = "dev" ]; then \
+		echo "\033[3mAlready inside hatch dev shell — skipping \033[0;36m'hatch shell dev'\033[0m"; \
+	else \
+		hatch shell dev; \
+	fi
 
 .PHONY: init hatch-install  ## setup - Install Hatch (on Mac)
 hatch-install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ async-http = [
 ]
 box = ["boxsdk[jwt]==3.8.1"]
 pandas = ["pyspark[pandas-on-spark]>=3.2.0"]
+# NOTE: pyspark<4.0 imports the private `pandas.core.common._builtin_table`
+# symbol (see `pyspark/pandas/groupby.py:50`), which pandas removed in 2.2.0.
+# We intentionally do NOT cap pandas here — instead the upper bound is added
+# in the places where we actually pin pyspark<4.0 (the `dev` env's
+# `extra-dependencies` and the per-pyspark-version test matrix overrides
+# below). End users installing `koheesio[pandas]` alongside pyspark<4 should
+# pin `pandas<2.2` themselves until pyspark 4.0 ships and that constraint
+# is no longer needed.
 pyspark = [
   "pyspark>=3.2.0",
   "pyarrow>13",
@@ -324,6 +332,9 @@ matrix.version.extra-dependencies = [
   { value = "pyspark==3.5.2", if = ["pyspark352"] },
   { value = "pyspark[connect]==3.5.2", if = ["pyspark352r"] },
   { value = "delta-spark>=3.0", if = ["pyspark352", "pyspark352r"] },
+  # pyspark<4.0 needs pandas<2.2 (private `_builtin_table` import). pyspark33
+  # already has the stricter `pandas<2` above, so it doesn't need this entry.
+  { value = "pandas<2.2", if = ["pyspark34", "pyspark35", "pyspark35r", "pyspark352", "pyspark352r"] },
 ]
 
 name.".*".env-vars = [
@@ -456,7 +467,12 @@ features = [
   "test",
   "docs",
 ]
-extra-dependencies = ["pyspark[connect]==3.5.4"]
+extra-dependencies = [
+  "pyspark[connect]==3.5.4",
+  # pyspark<4.0 imports `pandas.core.common._builtin_table` (removed in
+  # pandas 2.2.0). Drop alongside the pyspark pin once we upgrade.
+  "pandas<2.2",
+]
 
 # Enable this if you want Spark Connect in your dev environment
 [tool.hatch.envs.dev.env-vars]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,17 @@ async-http = [
   "nest-asyncio>=1.6.0",
 ]
 box = ["boxsdk[jwt]==3.8.1"]
-pandas = ["pandas>=1.3", "setuptools", "numpy<2.0.0", "pandas-stubs"]
-pyspark = ["pyspark>=3.2.0", "pyarrow>13"]
+pandas = ["pyspark[pandas-on-spark]>=3.2.0"]
+pyspark = [
+  "pyspark>=3.2.0",
+  "pyarrow>13",
+  # pyspark<4.0 still imports `distutils.version.LooseVersion`, which was
+  # removed from the stdlib in Python 3.12. setuptools ships a `distutils`
+  # compatibility shim (auto-activated via its `distutils-precedence.pth`),
+  # so installing it restores the import on 3.12+. Drop once we move to
+  # pyspark 4.0 (which no longer uses distutils).
+  "setuptools; python_version >= '3.12'",
+]
 pyspark_connect = ["pyspark[connect]>=3.5"]
 sftp = ["paramiko>=2.6.0"]
 delta = ["delta-spark>=2.2"]


### PR DESCRIPTION
## Summary

Fixes two unrelated import errors that surface when running koheesio on Python 3.12 with PySpark 3.5.x, and tightens the `make dev` workflow.

### `pandas` extra now sources pandas via `pyspark[pandas-on-spark]`

Before:
`pandas = ["pandas>=1.3", "setuptools", "numpy<2.0.0", "pandas-stubs"]`

After:
`pandas = ["pyspark[pandas-on-spark]>=3.2.0"]`

- `koheesio.pandas` is implemented on top of `pyspark.pandas` (`PandasStep` calls `import_pandas_based_on_pyspark_version` from `koheesio.spark.utils`), so the `pandas` extra always required pyspark to function. Routing it through `pyspark[pandas-on-spark]` lets pyspark drive pandas/pyarrow/numpy version selection (the extra declares `pandas>=1.0.5`, `pyarrow>=4.0.0`, `numpy<2,>=1.15`) instead of duplicating those bounds in koheesio.
- This was triggered by `ImportError: cannot import name '_builtin_table' from 'pandas.core.common'` in `pyspark/pandas/groupby.py:50`. PySpark <=3.5.x imports a private symbol that pandas removed in 2.2.0; the PySpark-side fix only landed in Spark 4.0.

### `pyspark` extra installs `setuptools` on Python 3.12+

```toml
pyspark = [
  "pyspark>=3.2.0",
  "pyarrow>13",
  "setuptools; python_version >= '3.12'",
]