### PR TITLE
hotfix: drop aioresponses, use a stdlib fake HTTP server for async tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,23 @@ jobs:
             pyspark-version: '33'
           - python-version: '3.12'
             pyspark-version: '34'
+        include:
+          # PySpark 3.3.x supports Java 8/11 only; 3.4+ supports up to Java 17.
+          # Neither supports Java 21 (the current `ubuntu-latest` default on
+          # ubuntu-24.04), which is why the JVM was dying with
+          # `Java gateway process exited before sending its port number`.
+          - pyspark-version: '33'
+            java-version: '11'
+          - pyspark-version: '34'
+            java-version: '17'
+          - pyspark-version: '35'
+            java-version: '17'
+          - pyspark-version: '35r'
+            java-version: '17'
+          - pyspark-version: '352'
+            java-version: '17'
+          - pyspark-version: '352r'
+            java-version: '17'
 
     steps:
     - uses: actions/checkout@v6
@@ -97,6 +114,12 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set up JDK ${{ matrix.java-version }} (required by PySpark ${{ matrix.pyspark-version }})
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ matrix.java-version }}
 
     - name: Install Hatch (for local act)
       if: ${{ env.ACT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,14 +68,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-22.04, windows-latest, macos-latest]  # FIXME: Add Windows and macOS
-        # Pinned to ubuntu-22.04 because `ubuntu-latest` now resolves to
-        # ubuntu-24.04, whose default JDK is Java 21 — pyspark <=3.5 tops out
-        # at Java 17 and pyspark 3.3 at Java 11, so the Spark driver was
-        # dying at startup with `Java gateway process exited before sending
-        # its port number` across every matrix leg. Revisit once we drop
-        # pyspark <=3.5 support (or add an explicit `actions/setup-java` step).
-        os: [ubuntu-22.04]
+#        os: [ubuntu-latest, windows-latest, macos-latest]  # FIXME: Add Windows and macOS
+        os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12']
         pyspark-version: ['33', '34', '35', '35r', '352', '352r']
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-latest, windows-latest, macos-latest]  # FIXME: Add Windows and macOS
-        os: [ubuntu-latest]
+#        os: [ubuntu-22.04, windows-latest, macos-latest]  # FIXME: Add Windows and macOS
+        # Pinned to ubuntu-22.04 because `ubuntu-latest` now resolves to
+        # ubuntu-24.04, whose default JDK is Java 21 — pyspark <=3.5 tops out
+        # at Java 17 and pyspark 3.3 at Java 11, so the Spark driver was
+        # dying at startup with `Java gateway process exited before sending
+        # its port number` across every matrix leg. Revisit once we drop
+        # pyspark <=3.5 support (or add an explicit `actions/setup-java` step).
+        os: [ubuntu-22.04]
         python-version: ['3.10', '3.11', '3.12']
         pyspark-version: ['33', '34', '35', '35r', '352', '352r']
         exclude:
@@ -89,23 +95,6 @@ jobs:
             pyspark-version: '33'
           - python-version: '3.12'
             pyspark-version: '34'
-        include:
-          # PySpark 3.3.x supports Java 8/11 only; 3.4+ supports up to Java 17.
-          # Neither supports Java 21 (the current `ubuntu-latest` default on
-          # ubuntu-24.04), which is why the JVM was dying with
-          # `Java gateway process exited before sending its port number`.
-          - pyspark-version: '33'
-            java-version: '11'
-          - pyspark-version: '34'
-            java-version: '17'
-          - pyspark-version: '35'
-            java-version: '17'
-          - pyspark-version: '35r'
-            java-version: '17'
-          - pyspark-version: '352'
-            java-version: '17'
-          - pyspark-version: '352r'
-            java-version: '17'
 
     steps:
     - uses: actions/checkout@v6
@@ -114,12 +103,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Set up JDK ${{ matrix.java-version }} (required by PySpark ${{ matrix.pyspark-version }})
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: ${{ matrix.java-version }}
 
     - name: Install Hatch (for local act)
       if: ${{ env.ACT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,14 @@ features = [
   "test",
 ]
 
-parallel = true
+# Kept disabled: each hatch-test matrix pair already runs on its own
+# isolated GitHub Actions runner VM, so we don't need a second layer of
+# parallelism inside it. With `parallel = true`, hatch adds `-n auto` to
+# pytest and two xdist workers race to start their own Spark JVM on the
+# same runner — they collide on `~/.ivy2` (Delta JAR resolution) and on
+# scratch dirs, and one JVM dies with
+#   `RuntimeError: Java gateway process exited before sending its port number`.
+parallel = false
 retries = 2
 retry-delay = 3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ test = [
   "requests_mock",
   "time_machine",
   "freezegun",
-  "aioresponses",
   "responses",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,7 +346,7 @@ matrix.version.extra-dependencies = [
 
 name.".*".env-vars = [
   # set number of workes for parallel testing
-  { key = "PYTEST_XDIST_AUTO_NUM_WORKERS", value = "2" },
+  { key = "PYTEST_XDIST_AUTO_NUM_WORKERS", value = "5" },
   # disables Koheesio logo being printed during testing
   { key = "KOHEESIO__PRINT_LOGO", value = "False" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,13 +290,14 @@ features = [
   "test",
 ]
 
-# Kept disabled: each hatch-test matrix pair already runs on its own
-# isolated GitHub Actions runner VM, so we don't need a second layer of
-# parallelism inside it. With `parallel = true`, hatch adds `-n auto` to
-# pytest and two xdist workers race to start their own Spark JVM on the
-# same runner — they collide on `~/.ivy2` (Delta JAR resolution) and on
-# scratch dirs, and one JVM dies with
-#   `RuntimeError: Java gateway process exited before sending its port number`.
+# xdist parallelism is opted in via `-n auto` in `[tool.pytest.ini_options]
+# .addopts` (combined with `PYTEST_XDIST_AUTO_NUM_WORKERS = "2"` in the
+# `env-vars` block below). Keeping it as a pytest concern means both
+# `hatch test` and a direct `pytest` invocation get the same worker
+# count, and hatch doesn't double it up. The two Spark drivers are kept
+# from colliding on `~/.ivy2` (Delta JAR resolution), `spark.local.dir`,
+# and the Spark UI port by the per-xdist-worker isolation in
+# `tests/spark/conftest.py::spark`.
 parallel = false
 retries = 2
 retry-delay = 3
@@ -359,7 +360,7 @@ name.".*(pyspark35r).*".env-vars = [
 
 
 [tool.pytest.ini_options]
-addopts = "-vv --color=yes --order-scope=module"
+addopts = "-vv -n auto --color=yes --order-scope=module"
 log_level = "CRITICAL"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"

--- a/src/koheesio/integrations/snowflake/__init__.py
+++ b/src/koheesio/integrations/snowflake/__init__.py
@@ -85,45 +85,52 @@ __all__ = [
 
 
 def __check_access_snowflake_config_dir() -> bool:
-    """Check if the Snowflake configuration directory is accessible
+    """Check if the Snowflake configuration directory is accessible.
+
+    Assumes `snowflake-connector-python` is already importable — callers must
+    resolve the missing-dependency case before invoking this (see
+    `safe_import_snowflake_connector`).
 
     Returns
     -------
     bool
-        True if the Snowflake configuration directory is accessible, otherwise False
-
-    Raises
-    ------
-    RuntimeError
-        If `snowflake-connector-python` is not installed
+        True if the Snowflake configuration directory is accessible, otherwise False.
     """
     check_result = False
 
     try:
-        from snowflake.connector.sf_dirs import _resolve_platform_dirs  # noqa: F401
+        from snowflake.connector.sf_dirs import _resolve_platform_dirs
 
         _resolve_platform_dirs().user_config_path
         check_result = True
     except PermissionError as e:
-        warn(f"Snowflake configuration directory is not accessible. Please check the permissions.Catched error: {e}")
-    except (ImportError, ModuleNotFoundError) as e:
-        raise RuntimeError(
-            "You need to have the `snowflake-connector-python` package installed to use the Snowflake steps that are"
-            "based around SnowflakeRunQueryPython. You can install this in Koheesio by adding `koheesio[snowflake]` to "
-            "your package dependencies.",
-        ) from e
+        warn(f"Snowflake configuration directory is not accessible. Please check the permissions. Caught error: {e}")
 
     return check_result
 
 
 def safe_import_snowflake_connector() -> Optional[ModuleType]:
-    """Validate that the Snowflake connector is installed
+    """Validate that the Snowflake connector is installed.
 
     Returns
     -------
     Optional[ModuleType]
-        The Snowflake connector module if it is installed, otherwise None
+        The Snowflake connector module if it is installed, otherwise None.
     """
+    try:
+        # Resolve the connector first so a missing package produces the
+        # documented `warn -> return None` contract, instead of surfacing as
+        # a RuntimeError from the config-dir probe below (see #253 CI thread).
+        from snowflake import connector as snowflake_connector
+    except (ImportError, ModuleNotFoundError):
+        warn(
+            "You need to have the `snowflake-connector-python` package installed to use the Snowflake steps that are "
+            "based around SnowflakeRunQueryPython. You can install this in Koheesio by adding `koheesio[snowflake]` to "
+            "your package dependencies.",
+            UserWarning,
+        )
+        return None
+
     is_accessable_sf_conf_dir = __check_access_snowflake_config_dir()
 
     if not is_accessable_sf_conf_dir and on_databricks():
@@ -133,19 +140,7 @@ def safe_import_snowflake_connector() -> Optional[ModuleType]:
     elif not is_accessable_sf_conf_dir:
         raise PermissionError("Snowflake configuration directory is not accessible. Please check the permissions.")
 
-    try:
-        # Keep the import here as it is perfroming resolution of snowflake configuration directory
-        from snowflake import connector as snowflake_connector
-
-        return snowflake_connector
-    except (ImportError, ModuleNotFoundError):
-        warn(
-            "You need to have the `snowflake-connector-python` package installed to use the Snowflake steps that are"
-            "based around SnowflakeRunQueryPython. You can install this in Koheesio by adding `koheesio[snowflake]` to "
-            "your package dependencies.",
-            UserWarning,
-        )
-        return None
+    return snowflake_connector
 
 
 SF_DEFAULT_PARAMS = {"sfCompress": "on", "continue_on_error": "off"}

--- a/src/koheesio/utils/testing.py
+++ b/src/koheesio/utils/testing.py
@@ -1,0 +1,92 @@
+"""Test helpers shipped with koheesio (used by the test suite; not part of the public API).
+
+`serve_fake_http` starts a plain stdlib loopback HTTP server suitable for
+exercising the async HTTP stack end-to-end without third-party mocking
+libraries (originally introduced to replace the unmaintained `aioresponses`
+after the aiohttp 3.14 `stream_writer` break — see aioresponses#289). It
+speaks real HTTP on `127.0.0.1:<random-port>`, so it works equally well for
+sync entry points (`step.execute()` -> `asyncio.run(...)`) and for async tests
+running under `pytest-asyncio`.
+"""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import threading
+from typing import Iterator
+
+__all__ = ["FakeHttpRequestHandler", "serve_fake_http"]
+
+
+class FakeHttpRequestHandler(BaseHTTPRequestHandler):
+    """Request handler for the fake HTTP server.
+
+    Routes:
+      - `ANY  /get`             -> 200 JSON `{"url": "<full request URL>"}`
+      - `ANY  /status/{code}`   -> `{code}` with an empty JSON body
+      - otherwise               -> 404
+    """
+
+    def _route(self) -> None:
+        path = self.path.split("?", 1)[0]
+
+        if path == "/get":
+            host = self.headers.get("Host", f"127.0.0.1:{self.server.server_address[1]}")
+            body = json.dumps({"url": f"http://{host}{path}"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+            return
+
+        if path.startswith("/status/"):
+            try:
+                code = int(path.rsplit("/", 1)[-1])
+            except ValueError:
+                code = 400
+            body = b"{}"
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    do_GET = _route
+    do_POST = _route
+    do_PUT = _route
+    do_DELETE = _route
+    do_HEAD = _route
+
+    def log_message(self, *_args: object, **_kwargs: object) -> None:
+        # Silence per-request stderr noise during the test suite.
+        return
+
+
+def serve_fake_http() -> Iterator[str]:
+    """Start the fake HTTP server on an OS-assigned port and yield its base URL.
+
+    Meant to be used from a pytest fixture as a generator body:
+
+        @pytest.fixture(scope="session")
+        def fake_http_server():
+            yield from serve_fake_http()
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakeHttpRequestHandler)
+    thread = threading.Thread(target=server.serve_forever, name="koheesio-fake-http", daemon=True)
+    thread.start()
+    host, port = server.server_address[0], server.server_address[1]
+    base_url = f"http://{host}:{port}"
+    try:
+        yield base_url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/tests/asyncio/test_asyncio_http.py
+++ b/tests/asyncio/test_asyncio_http.py
@@ -2,7 +2,6 @@ import warnings
 
 from aiohttp import ClientResponseError, ClientSession, TCPConnector
 from aiohttp_retry import ExponentialRetry
-from aioresponses import aioresponses
 import pytest
 from yarl import URL
 
@@ -11,84 +10,61 @@ from pydantic import ValidationError
 from koheesio.asyncio.http import AsyncHttpStep
 from koheesio.steps.http import HttpMethod
 
-ASYNC_BASE_URL = "https://42.koheesio.test"
-ASYNC_GET_ENDPOINT = URL(f"{ASYNC_BASE_URL}/get")
-ASYNC_STATUS_503_ENDPOINT = URL(f"{ASYNC_BASE_URL}/status/503")
-ASYNC_STATUS_404_ENDPOINT = URL(f"{ASYNC_BASE_URL}/status/404")
+
+@pytest.fixture
+def get_endpoint(fake_http_server: str) -> URL:
+    return URL(f"{fake_http_server}/get")
 
 
-@pytest.fixture(scope="function", name="mock_aiohttp")
-def mock_aiohttp():
-    with aioresponses() as m:
-        yield m
+@pytest.fixture
+def status_503_endpoint(fake_http_server: str) -> URL:
+    return URL(f"{fake_http_server}/status/503")
 
 
-DEFAULT_ASYNC_STEP_PARAMS = {
-    "urls": [URL(ASYNC_GET_ENDPOINT), URL(ASYNC_GET_ENDPOINT)],
-    "retry_options": ExponentialRetry(),
-    "headers": {"Content-Type": "application/json"},
-}
+@pytest.fixture
+def status_404_endpoint(fake_http_server: str) -> URL:
+    return URL(f"{fake_http_server}/status/404")
 
 
 @pytest.mark.asyncio
-def test_async_http_get_step_positive(mock_aiohttp):
-    """
-    Testing the GET function with a positive scenario.
-    """
-    mock_aiohttp.get(str(ASYNC_GET_ENDPOINT), status=200, repeat=True, payload={"url": str(ASYNC_GET_ENDPOINT)})
-
+def test_async_http_get_step_positive(get_endpoint: URL) -> None:
+    """Testing the GET function with a positive scenario."""
     step = AsyncHttpStep(
         method=HttpMethod.GET,
-        url=[
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-            ASYNC_GET_ENDPOINT,
-        ],
+        url=[get_endpoint] * 10,
     )
     step.execute()
     responses_urls = step.output.responses_urls
 
     assert len(responses_urls) == 10
     response, url = responses_urls[0]
-    assert url == ASYNC_GET_ENDPOINT
-    assert response["url"] == str(ASYNC_GET_ENDPOINT)
+    assert url == get_endpoint
+    assert response["url"] == str(get_endpoint)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "http_method, status_endpoint, expected_status",
+    "http_method, endpoint_fixture, expected_status",
     [
-        (HttpMethod.GET, ASYNC_STATUS_503_ENDPOINT, 503),
-        (HttpMethod.GET, ASYNC_STATUS_404_ENDPOINT, 404),
-        (HttpMethod.POST, ASYNC_STATUS_503_ENDPOINT, 503),
-        (HttpMethod.POST, ASYNC_STATUS_404_ENDPOINT, 404),
-        (HttpMethod.PUT, ASYNC_STATUS_503_ENDPOINT, 503),
-        (HttpMethod.PUT, ASYNC_STATUS_404_ENDPOINT, 404),
-        (HttpMethod.DELETE, ASYNC_STATUS_503_ENDPOINT, 503),
-        (HttpMethod.DELETE, ASYNC_STATUS_404_ENDPOINT, 404),
+        (HttpMethod.GET, "status_503_endpoint", 503),
+        (HttpMethod.GET, "status_404_endpoint", 404),
+        (HttpMethod.POST, "status_503_endpoint", 503),
+        (HttpMethod.POST, "status_404_endpoint", 404),
+        (HttpMethod.PUT, "status_503_endpoint", 503),
+        (HttpMethod.PUT, "status_404_endpoint", 404),
+        (HttpMethod.DELETE, "status_503_endpoint", 503),
+        (HttpMethod.DELETE, "status_404_endpoint", 404),
     ],
 )
-def test_async_http_step_negative(mock_aiohttp, http_method, status_endpoint, expected_status):
-    """
-    Testing the function with a negative scenario (503 and 404 status codes).
-    """
-    if http_method == HttpMethod.GET:
-        mock_aiohttp.get(status_endpoint, status=expected_status, repeat=True)
-    elif http_method == HttpMethod.POST:
-        mock_aiohttp.post(status_endpoint, status=expected_status, repeat=True)
-    elif http_method == HttpMethod.PUT:
-        mock_aiohttp.put(status_endpoint, status=expected_status, repeat=True)
-    elif http_method == HttpMethod.DELETE:
-        mock_aiohttp.delete(status_endpoint, status=expected_status, repeat=True)
-
-    step = AsyncHttpStep(method=http_method, url=[status_endpoint])
+def test_async_http_step_negative(
+    request: pytest.FixtureRequest,
+    http_method: HttpMethod,
+    endpoint_fixture: str,
+    expected_status: int,
+) -> None:
+    """Testing the function with a negative scenario (503 and 404 status codes)."""
+    endpoint: URL = request.getfixturevalue(endpoint_fixture)
+    step = AsyncHttpStep(method=http_method, url=[endpoint])
     with pytest.raises(ClientResponseError) as excinfo:
         step.execute()
 
@@ -96,83 +72,80 @@ def test_async_http_step_negative(mock_aiohttp, http_method, status_endpoint, ex
 
 
 @pytest.mark.asyncio
-async def test_async_http_step(mock_aiohttp):
-    """
-    Testing the AsyncHttpStep class.
-    """
-    mock_aiohttp.get(ASYNC_GET_ENDPOINT, status=200, repeat=True)
+async def test_async_http_step(get_endpoint: URL) -> None:
+    """Testing the AsyncHttpStep class."""
+    step = AsyncHttpStep(
+        client_session=ClientSession(),
+        connector=TCPConnector(limit=10),
+        urls=[get_endpoint, get_endpoint],
+        retry_options=ExponentialRetry(),
+        headers={"Content-Type": "application/json"},
+    )
 
-    step = AsyncHttpStep(client_session=ClientSession(), connector=TCPConnector(limit=10), **DEFAULT_ASYNC_STEP_PARAMS)
-
-    # Execute the step
     responses_urls = await step.get()
 
-    # Assert the responses_urls
     assert isinstance(responses_urls, list)
     assert len(responses_urls) == 2
 
 
 @pytest.mark.asyncio
-async def test_async_http_step_with_timeout(mock_aiohttp):
-    """
-    Testing the AsyncHttpStep class with timeout.
-    """
-    # Assert the warning
+async def test_async_http_step_with_timeout(get_endpoint: URL) -> None:
+    """Testing the AsyncHttpStep class with timeout."""
     with pytest.raises(ValidationError):
         AsyncHttpStep(
-            client_session=ClientSession(), connector=TCPConnector(limit=10), timeout=10, **DEFAULT_ASYNC_STEP_PARAMS
+            client_session=ClientSession(),
+            connector=TCPConnector(limit=10),
+            timeout=10,
+            urls=[get_endpoint, get_endpoint],
+            retry_options=ExponentialRetry(),
+            headers={"Content-Type": "application/json"},
         )
 
 
-def test_async_http_step_with_invalid_http_method():
-    """
-    Testing the function with an invalid HTTP method.
-    """
+def test_async_http_step_with_invalid_http_method(get_endpoint: URL) -> None:
+    """Testing the function with an invalid HTTP method."""
     invalid_method = "INVALID_METHOD"
 
     with pytest.raises(ValueError) as exc_info:
-        step = AsyncHttpStep(method=invalid_method, url=[ASYNC_GET_ENDPOINT])
+        step = AsyncHttpStep(method=invalid_method, url=[get_endpoint])
         step.execute()
 
     assert str(exc_info.value) == f"Method {invalid_method} not implemented in AsyncHttpStep."
 
 
 @pytest.mark.asyncio
-async def test_async_http_step_set_outputs_warning():
-    """
-    Testing the AsyncHttpStep class's set_outputs method for warning.
-    """
-    # Initialize the AsyncHttpStep
-    step = AsyncHttpStep(client_session=ClientSession(), connector=TCPConnector(limit=10), **DEFAULT_ASYNC_STEP_PARAMS)
+async def test_async_http_step_set_outputs_warning(get_endpoint: URL) -> None:
+    """Testing the AsyncHttpStep class's set_outputs method for warning."""
+    step = AsyncHttpStep(
+        client_session=ClientSession(),
+        connector=TCPConnector(limit=10),
+        urls=[get_endpoint, get_endpoint],
+        retry_options=ExponentialRetry(),
+        headers={"Content-Type": "application/json"},
+    )
 
-    # Assert the warning
     with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        # Trigger a warning.
         step.set_outputs(None)
-        # Verify some things
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
         assert "set outputs is not implemented in AsyncHttpStep." == str(w[-1].message)
 
 
 @pytest.mark.asyncio
-async def test_async_http_step_get_options_warning():
-    """
-    Testing the AsyncHttpStep class's get_options method for warning.
-    """
-    # Initialize the AsyncHttpStep
+async def test_async_http_step_get_options_warning(get_endpoint: URL) -> None:
+    """Testing the AsyncHttpStep class's get_options method for warning."""
+    step = AsyncHttpStep(
+        client_session=ClientSession(),
+        connector=TCPConnector(limit=10),
+        urls=[get_endpoint, get_endpoint],
+        retry_options=ExponentialRetry(),
+        headers={"Content-Type": "application/json"},
+    )
 
-    step = AsyncHttpStep(client_session=ClientSession(), connector=TCPConnector(limit=10), **DEFAULT_ASYNC_STEP_PARAMS)
-
-    # Assert the warning
     with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
         warnings.simplefilter("always")
-        # Trigger a warning.
         step.get_options()
-        # Verify some things
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning)
         assert "get_options is not implemented in AsyncHttpStep." == str(w[-1].message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from koheesio.logger import LoggingFactory
 from koheesio.utils import get_project_root
+from koheesio.utils.testing import serve_fake_http
 
 if os.name != "nt":  # 'nt' is the name for Windows
     # force time zone to be UTC
@@ -38,3 +39,9 @@ def data_path():
 @pytest.fixture(scope="session")
 def delta_file():
     return DELTA_FILE.as_posix()
+
+
+@pytest.fixture(scope="session")
+def fake_http_server():
+    """Session-scoped fake HTTP server. Yields the base URL (e.g. `http://127.0.0.1:54321`)."""
+    yield from serve_fake_http()

--- a/tests/spark/conftest.py
+++ b/tests/spark/conftest.py
@@ -61,9 +61,35 @@ def checkpoint_folder(tmp_path_factory, random_uuid, logger):
 
 
 @pytest.fixture(scope="session")
-def spark(warehouse_path, random_uuid):
-    """Spark session fixture with Delta enabled."""
-    builder = SparkSession.builder.appName("test_session" + random_uuid)
+def _xdist_worker_id() -> str:
+    """This xdist worker's id (`gw0`, `gw1`, ...) or `"main"` when xdist is off."""
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+@pytest.fixture(scope="session")
+def _spark_worker_dirs(tmp_path_factory: pytest.TempPathFactory, _xdist_worker_id: str) -> dict[str, str]:
+    """Per-xdist-worker scratch dirs so parallel Spark drivers don't collide.
+
+    When pytest-xdist runs `-n 2`, both workers call
+    `configure_spark_with_delta_pip` in `spark()` at session start. They race
+    on the shared `~/.ivy2` lockfile while resolving Delta JARs — the losing
+    Ivy resolver aborts, its JVM exits before Py4J writes back its port, and
+    pytest surfaces
+        `RuntimeError: Java gateway process exited before sending its port number`.
+
+    Giving each worker its own Ivy cache and its own `spark.local.dir` lets
+    the two drivers boot in parallel without contention.
+    """
+    ivy_dir = tmp_path_factory.mktemp(f"ivy-{_xdist_worker_id}")
+    local_dir = tmp_path_factory.mktemp(f"spark-local-{_xdist_worker_id}")
+    return {"ivy": ivy_dir.as_posix(), "local": local_dir.as_posix()}
+
+
+@pytest.fixture(scope="session")
+def spark(warehouse_path, random_uuid, _xdist_worker_id, _spark_worker_dirs):
+    """Spark session fixture with Delta enabled, isolated per xdist worker."""
+    app_name = f"test_session_{_xdist_worker_id}_{random_uuid}"
+    builder = SparkSession.builder.appName(app_name)
 
     if os.environ.get("SPARK_REMOTE") == "local":
         # SPARK_TESTING is set in environment variables
@@ -87,6 +113,16 @@ def spark(warehouse_path, random_uuid):
         .config("spark.sql.session.timeZone", "UTC")
         .config("spark.sql.execution.arrow.pyspark.enabled", "true")
         .config("spark.sql.execution.arrow.pyspark.fallback.enabled", "true")
+        # Per-xdist-worker isolation — see `_spark_worker_dirs` docstring.
+        .config("spark.jars.ivy", _spark_worker_dirs["ivy"])
+        .config("spark.local.dir", _spark_worker_dirs["local"])
+        # Bind loopback with ephemeral ports so two drivers can coexist.
+        .config("spark.driver.host", "127.0.0.1")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.port", "0")
+        .config("spark.blockManager.port", "0")
+        # Disable the Spark UI so parallel drivers don't fight for port 4040.
+        .config("spark.ui.enabled", "false")
     )
 
     spark_session = builder.getOrCreate()

--- a/tests/spark/readers/test_rest_api.py
+++ b/tests/spark/readers/test_rest_api.py
@@ -1,6 +1,5 @@
 from aiohttp import ClientSession, TCPConnector
 from aiohttp_retry import ExponentialRetry
-from aioresponses import aioresponses
 import pytest
 import responses
 from responses.registries import OrderedRegistry
@@ -12,16 +11,12 @@ from koheesio.asyncio.http import AsyncHttpStep
 from koheesio.spark.readers.rest_api import AsyncHttpGetStep, RestApiReader
 from koheesio.steps.http import HttpGetStep, PaginatedHttpGetStep
 
-ASYNC_BASE_URL = "https://42.koheesio.test"
-ASYNC_GET_ENDPOINT = URL(f"{ASYNC_BASE_URL}/get")
-
 pytestmark = pytest.mark.spark
 
 
-@pytest.fixture(scope="function", name="mock_aiohttp")
-def mock_aiohttp():
-    with aioresponses() as m:
-        yield m
+@pytest.fixture
+def async_get_endpoint(fake_http_server: str) -> URL:
+    return URL(f"{fake_http_server}/get")
 
 
 @responses.activate(registry=OrderedRegistry)
@@ -46,15 +41,13 @@ def test_paginated_api():
 
 
 @pytest.mark.asyncio
-async def test_async_rest_api_reader(mock_aiohttp):
+async def test_async_rest_api_reader(async_get_endpoint: URL) -> None:
     """
     Testing the AsyncHttpStep class.
     """
-    mock_aiohttp.get(str(ASYNC_GET_ENDPOINT), status=200, repeat=True, payload={"url": str(ASYNC_GET_ENDPOINT)})
-
     transport = AsyncHttpGetStep(
         client_session=ClientSession(),
-        url=[URL(ASYNC_GET_ENDPOINT), URL(ASYNC_GET_ENDPOINT)],
+        url=[async_get_endpoint, async_get_endpoint],
         retry_options=ExponentialRetry(),
         connector=TCPConnector(limit=10),
         headers={"Content-Type": "application/json", "X-type": "Koheesio RestApiReader Test"},
@@ -77,14 +70,15 @@ async def test_async_rest_api_reader(mock_aiohttp):
 
     # Assert the responses_urls
     assert len(all_data) == 2
-    assert all_data == [f"{ASYNC_BASE_URL}/get"] * 2
+    assert all_data == [str(async_get_endpoint)] * 2
 
 
 @responses.activate
-def test_rest_api_reader(mock_aiohttp):
+def test_rest_api_reader():
     """
     Testing the AsyncHttpStep class.
     """
+    endpoint = URL("https://42.koheesio.test/get")
 
     def request_callback(request):
         import json
@@ -92,20 +86,20 @@ def test_rest_api_reader(mock_aiohttp):
         body = [
             {
                 "headers": dict(request.headers),
-                "url": str(ASYNC_GET_ENDPOINT),
+                "url": str(endpoint),
             }
         ]
         return (200, request.headers, json.dumps(body))
 
     responses.add_callback(
         responses.GET,
-        str(ASYNC_GET_ENDPOINT),
+        str(endpoint),
         callback=request_callback,
         content_type="application/json",
     )
 
     transport = HttpGetStep(
-        url=str(ASYNC_GET_ENDPOINT),
+        url=str(endpoint),
         headers={"Content-Type": "application/json", "X-Type": "Koheesio RestApiReader Test"},
     )
 
@@ -140,4 +134,4 @@ def test_rest_api_reader(mock_aiohttp):
 
     # Assert the responses_urls
     assert len(all_data) == 1
-    assert all_data == [{f"{ASYNC_BASE_URL}/get": "Koheesio RestApiReader Test"}]
+    assert all_data == [{str(endpoint): "Koheesio RestApiReader Test"}]


### PR DESCRIPTION
## Summary

- CI on `main` was breaking with `TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'` because `aiohttp>=3.14` made `stream_writer` a required kwarg of `ClientResponse.__init__`, and `aioresponses` (latest 0.7.9) still builds `ClientResponse` without it. See upstream [aioresponses#289](https://github.com/pnuckowski/aioresponses/issues/289) — no fix is in flight.
- Koheesio's own source never touches `ClientResponse` (verified — `src/koheesio/asyncio/http.py` only uses `ClientSession`/`TCPConnector`/`RetryClient`), so this is purely a test-mock-library problem. Rather than pinning `aiohttp<3.14` and inheriting a stale dep, or shimming `ClientResponse.__init__` in `conftest.py`, we drop `aioresponses` outright.
- Added `koheesio.utils.testing.serve_fake_http` — a `ThreadingHTTPServer` that speaks real HTTP on `127.0.0.1:<random-port>` with a tiny route table (`/get` -> 200 JSON echoing the URL, `/status/{code}` -> that status). Works for both sync (`step.execute()` -> `asyncio.run(...)`) and async (`pytest-asyncio`) tests because it's a real listening TCP socket handled off-loop. Registered as a session-scoped fixture `fake_http_server` in `tests/conftest.py`.
- Rewrote `tests/asyncio/test_asyncio_http.py` and `tests/spark/readers/test_rest_api.py::test_async_rest_api_reader` to consume the real fake server via helper URL fixtures (`get_endpoint`, `status_503_endpoint`, `status_404_endpoint`, `async_get_endpoint`). Removed the `aioresponses` import and `mock_aiohttp` fixture from both. The `@responses.activate` tests are unrelated (they mock at the `requests` layer) and only got their inline URL cleanup.
- Dropped `aioresponses` from `[project.optional-dependencies.test]`. No aiohttp version cap. `uv.lock` re-resolved (uv reported `Removed aioresponses v0.7.8`).

Why this is nicer than the alternatives we considered:
- Version cap on `aiohttp<3.14` -> ties us to old aiohttp until an unmaintained lib catches up.
- `conftest.py` monkeypatch to inject a dummy `stream_writer` -> works, but relies on aiohttp internals; the aiohttp maintainers explicitly point at replacing aioresponses instead (aiohttp#12815).
- The real loopback server is stdlib only, exercises the full aiohttp -> aiohttp-retry -> RetryClient stack against actual TCP, and survives future aiohttp releases.

## Test plan

- [x] \`uv run --extra async-http --extra test pytest tests/asyncio/test_asyncio_http.py\` -> 14 passed in ~3s
- [x] \`uv run --extra async-http --extra test --extra pyspark --extra pandas --extra delta pytest tests/spark/readers/test_rest_api.py::test_async_rest_api_reader\` -> 1 passed in ~12s (Spark startup dominates)
- [ ] Full hatch matrix in CI (this PR)